### PR TITLE
Account type quality of life

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -12,3 +12,4 @@
  */
 
  @import 'bootstrap';
+ @import 'badge';

--- a/app/assets/stylesheets/badge.scss
+++ b/app/assets/stylesheets/badge.scss
@@ -1,0 +1,6 @@
+
+
+.badge--account-type {
+  @extend .badge-primary;
+  font-size: 150%;
+}

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -13,6 +13,8 @@ class ApplicationController < ActionController::Base
 
   protect_from_forgery with: :exception
 
+  devise_group :account, contains: [:user, :admin_user]
+
   def after_sign_in_path_for(resource)
     return root_path if resource.blank?
 

--- a/app/views/shared/_account_badge.html.erb
+++ b/app/views/shared/_account_badge.html.erb
@@ -1,0 +1,5 @@
+<% if signed_in? %>
+  <span class='badge badge--account-type'>
+    <%= current_account.class.name.first %>
+  </span>
+<% end %>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -7,12 +7,18 @@
   <ul class="navbar-nav flex-row"> 
     <% if current_user.present? %>
       <li class="nav-item">
-        <%= link_to 'Log out', destroy_user_session_path, method: :delete, class: 'nav-link' %>
+        <span class='d-inline-flex'>
+          <%= render partial: 'shared/account_badge' %>
+          <%= link_to 'Log out', destroy_user_session_path, method: :delete, class: 'nav-link' %>
+        </span>
       </li>
     <% end %>
     <% if current_admin_user.present? %>
       <li class="nav-item">
-        <%= link_to 'Log out', destroy_admin_user_session_path, method: :delete, class: 'nav-link' %>
+        <span class='d-inline-flex'>
+          <%= render partial: 'shared/account_badge' %>
+          <%= link_to 'Log out', destroy_admin_user_session_path, method: :delete, class: 'nav-link' %>
+        </span>
       </li>
     <% end %>
     <% unless signed_in? %>


### PR DESCRIPTION
Adds a helper to unify different account models, so current_account will work like current_user usually does with a single model.

Adds a badge to the header to show what account type you're logged in as.