### PR TITLE
Feature/2012 revoke access to share

### DIFF
--- a/app/controllers/user/shares_controller.rb
+++ b/app/controllers/user/shares_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class User::SharesController < User::BaseController
-  before_action :set_share, only: :show
+  before_action :set_share, only: %i[show revoke]
 
   # GET /shares
   def index
@@ -37,6 +37,17 @@ class User::SharesController < User::BaseController
         format.html { redirect_to user_share_path(@share), notice: 'Share was successfully created.' }
       else
         format.html { render :new }
+      end
+    end
+  end
+
+  # POST /shares/1/revoke
+  def revoke
+    respond_to do |format|
+      if @share.revoke(current_user)
+        format.html { redirect_to user_share_path(@share), notice: 'Share was successfully revoked.' }
+      else
+        redirect_back(fallback_location: root_path)
       end
     end
   end

--- a/app/models/share.rb
+++ b/app/models/share.rb
@@ -4,14 +4,14 @@ class Share < ApplicationRecord
   belongs_to :user
   belongs_to :recipient, polymorphic: true
   belongs_to :birth_record
-  belongs_to :revoker, polymorphic: true, required: false
+  belongs_to :revoker, polymorphic: true, optional: true
 
   validates :user, presence: true
   validates :recipient, presence: true
   validates :birth_record, presence: true
 
-  scope :active, -> { where(revoked?: false) }
-  scope :revoked, -> { where(revoked?: true) }
+  scope :active, -> { where 'revoked_at IS NULL' }
+  scope :revoked, -> { where 'revoked_at IS NOT NULL' }
 
   def revoked?
     revoker.present?

--- a/app/models/share.rb
+++ b/app/models/share.rb
@@ -4,8 +4,28 @@ class Share < ApplicationRecord
   belongs_to :user
   belongs_to :recipient, polymorphic: true
   belongs_to :birth_record
+  belongs_to :revoker, polymorphic: true, required: false
 
   validates :user, presence: true
   validates :recipient, presence: true
   validates :birth_record, presence: true
+
+  scope :active, -> { where(revoked?: false) }
+  scope :revoked, -> { where(revoked?: true) }
+
+  def revoked?
+    revoker.present?
+  end
+
+  def revoke(account)
+    # consider business logic for who can revoke a share. The expected case is
+    # the user who created the share originally, but it could also be the
+    # recipient, an admin?, or even the subject of the birth record if it was
+    # originally shared by a parent
+
+    update!(
+      revoker: account,
+      revoked_at: Time.now.utc
+    )
+  end
 end

--- a/app/views/shared/birth_records/_card.html.erb
+++ b/app/views/shared/birth_records/_card.html.erb
@@ -2,9 +2,13 @@
   <div class="card-body">
     <h5 class="card-title">
       <%= link_to user_birth_record_path(card) do %>
-        <%= card.first_and_middle_names.first %> <%= card.family_name %>
+        <%= card.short_name %>
       <% end %>
     </h5>
     <%= render partial: 'shared/birth_records/short_details', object: card %>
+    <div class="navbar navbar-expand flex-row mr-auto">
+      <%= link_to 'share', new_user_share_path(share: { birth_record_id: card.to_param }), class: 'nav-link' %>
+      <%= link_to 'remove', remove_user_birth_record_path(card), class: 'nav-link', method: :post %>
+    </div>
   </div>
 </div>

--- a/app/views/user/birth_records/find.html.erb
+++ b/app/views/user/birth_records/find.html.erb
@@ -22,7 +22,7 @@
   <div class='container'>
     Results:
     <% @results&.each do |record| %>
-      <%= link_to 'add', add_user_birth_record_path(record), class: 'pill pill-secondary', method: :post %>
+      <%= link_to 'add', add_user_birth_record_path(record), class: 'nav-link', method: :post %>
       <%= render partial: 'shared/birth_records/card', object: record %>
     <% end %>
   </div>

--- a/app/views/user/birth_records/index.html.erb
+++ b/app/views/user/birth_records/index.html.erb
@@ -2,17 +2,15 @@
   <h2>Associated records for <%= current_user.email %></h2>
 </section>
 <% if @birth_records.any? %>
+  <section>
+    <%= link_to 'Add more birth records', find_user_birth_records_path, class: 'nav-link' %>
+  </section>
   <% @birth_records.each do |record| %>
     <div class="user-birth-record" data-id="<%= record.to_param %>">
-      <%= link_to 'share', new_user_share_path(share: { birth_record_id: record.to_param }), class: 'pill pill-secondary' %>
-      <%= link_to 'remove', remove_user_birth_record_path(record), class: 'pill pill-secondary', method: :post %>
       <%= render partial: 'shared/birth_records/card', object: record %>
     </div>
   <% end %>
-  <section>
-    <%= link_to 'Add more birth records', find_user_birth_records_path %>
-  </section>
 <% else %>
   <p class="text-muted font-italic">There are currently no birth records for <%= current_user.email %>.</p>
-  <%= link_to 'Add a birth record', find_user_birth_records_path, class: "btn btn-primary" %>
+  <%= link_to 'Add a birth record', find_user_birth_records_path, class: "nav-link" %>
 <% end %>

--- a/app/views/user/birth_records/show.html.erb
+++ b/app/views/user/birth_records/show.html.erb
@@ -1,2 +1,12 @@
 <%= render partial: 'shared/birth_records/short_details', object: @birth_record %>
-<%= link_to 'share', new_user_share_path(share: { birth_record_id: @birth_record.to_param }), class: 'pill pill-secondary' %>
+<div class="navbar navbar-expand flex-row">
+  <ul class="navbar-nav mr-auto">
+    <li class="nav-item">
+      <%= link_to 'Back', user_birth_records_path, class: 'nav-link' %>
+    </li>
+    <li class="nav-item">
+      <%= link_to 'Share', new_user_share_path(share: { birth_record_id: @birth_record.to_param }), class: 'nav-link' %>
+    </li>
+  </ul>
+</div>
+

--- a/app/views/user/index.html.erb
+++ b/app/views/user/index.html.erb
@@ -5,11 +5,13 @@
   <div>
     <%= link_to( 
       "View associated birth records (#{current_user.birth_records.count})",
-      user_birth_records_path) %>
+      user_birth_records_path, class: 'nav-link'
+      ) %>
   </div>
   <div>
     <%= link_to(
       "View shared birth records (#{current_user.shares.count})",
-      user_shares_path) %>
+      user_shares_path, 
+      class: 'nav-link') %>
   </div>
 </section>

--- a/app/views/user/shares/_revoke_button.html.erb
+++ b/app/views/user/shares/_revoke_button.html.erb
@@ -1,0 +1,5 @@
+<% if share.revoked? %>
+  <span class="nav-link disabled">Revoke</span>
+<% else %>
+  <%= link_to 'Revoke', revoke_user_share_path(share), method: :revoke, class: 'nav-link' %>
+<% end %>

--- a/app/views/user/shares/index.html.erb
+++ b/app/views/user/shares/index.html.erb
@@ -16,7 +16,8 @@
         <td><%= share.birth_record.short_name %></td>
         <td><%= share.user.email %></td>
         <td><%= share.recipient.email %></td>
-        <td><%= link_to 'Show', user_share_path(share) %></td>
+        <td><%= link_to 'Show', user_share_path(share), class: 'nav-link' %></td>
+        <td><%= render partial: 'revoke_button', locals: {share: share} %></td>
       </tr>
     <% end %>
   </tbody>

--- a/app/views/user/shares/new.html.erb
+++ b/app/views/user/shares/new.html.erb
@@ -2,4 +2,4 @@
 
 <%= render 'form', share: @share, organisations: @organisations %>
 
-<%= link_to 'Back', user_shares_path %>
+<%= link_to 'Back', user_shares_path, class: 'nav-link' %>

--- a/app/views/user/shares/show.html.erb
+++ b/app/views/user/shares/show.html.erb
@@ -13,4 +13,23 @@
   <%= @share.recipient.email %>
 </p>
 
-<%= link_to 'Back', user_shares_path %>
+<p>
+  <strong>Revoked by:</strong>
+  <%= @share.revoker&.email %>
+</p>
+
+<p>
+  <strong>Revoked at:</strong>
+  <%= @share.revoked_at %>
+</p>
+
+<div class="navbar navbar-expand flex-row">
+  <ul class="navbar-nav mr-auto">
+    <li class="nav-item">
+      <%= link_to 'Back', user_shares_path, class: 'nav-link' %>
+    </li>
+    <li class="nav-item">
+      <%= render partial: 'revoke_button', locals: {share: @share} %>
+    </li>
+  </ul>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -27,7 +27,11 @@ Rails.application.routes.draw do
         post :remove
       end
     end
-    resources :shares, only: %i[index show new create]
+    resources :shares, only: %i[index show new create] do
+      member do
+        post :revoke
+      end
+    end
   end
 
   authenticated :user do

--- a/db/migrate/20190618213242_add_revoker_to_shares.rb
+++ b/db/migrate/20190618213242_add_revoker_to_shares.rb
@@ -1,0 +1,8 @@
+class AddRevokerToShares < ActiveRecord::Migration[5.2]
+  def change
+    change_table :shares do |t|
+      t.references :revoker, polymorphic: true, index: true
+      t.datetime :revoked_at
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_06_13_045818) do
+ActiveRecord::Schema.define(version: 2019_06_18_213242) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -79,8 +79,12 @@ ActiveRecord::Schema.define(version: 2019_06_13_045818) do
     t.bigint "recipient_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "revoker_type"
+    t.bigint "revoker_id"
+    t.datetime "revoked_at"
     t.index ["birth_record_id"], name: "index_shares_on_birth_record_id"
     t.index ["recipient_type", "recipient_id"], name: "index_shares_on_recipient_type_and_recipient_id"
+    t.index ["revoker_type", "revoker_id"], name: "index_shares_on_revoker_type_and_revoker_id"
     t.index ["user_id"], name: "index_shares_on_user_id"
   end
 

--- a/spec/factories/share.rb
+++ b/spec/factories/share.rb
@@ -9,5 +9,10 @@ FactoryBot.define do
     trait :for_organisation_user do
       association :recipient, factory: :organisation_user
     end
+
+    trait :revoked do
+      association :revoker, factory: :user
+      revoked_at { Time.now.utc }
+    end
   end
 end

--- a/spec/models/share_spec.rb
+++ b/spec/models/share_spec.rb
@@ -3,11 +3,66 @@
 require 'rails_helper'
 
 RSpec.describe Share, type: :model do
-  describe 'Factory' do
+  describe 'an active share' do
     subject { FactoryBot.create(:share) }
 
     it 'is valid' do
       expect(subject).to be_valid
+    end
+
+    it 'is not revoked' do
+      expect(subject).not_to be_revoked
+    end
+
+    it 'is in the #active scope' do
+      expect(Share.active).to include(subject)
+    end
+
+
+    it 'can be revoked by a user' do
+      account = FactoryBot.create(:user)
+      subject.revoke(account)
+      subject.reload
+
+      expect(subject).to be_revoked
+      expect(subject.revoked_at).not_to be_nil
+      expect(subject.revoker).to eq(account)
+    end
+
+    it 'can be revoked by an admin' do
+      account = FactoryBot.create(:admin_user)
+      subject.revoke(account)
+      subject.reload
+
+      expect(subject).to be_revoked
+      expect(subject.revoked_at).not_to be_nil
+      expect(subject.revoker).to eq(account)
+    end
+
+    it 'can be revoked by an organisation' do
+      account = FactoryBot.create(:organisation_user)
+      subject.revoke(account)
+      subject.reload
+
+      expect(subject).to be_revoked
+      expect(subject.revoked_at).not_to be_nil
+      expect(subject.revoker).to eq(account)
+    end
+  end
+
+  describe 'a revoked share' do
+    subject { FactoryBot.create(:share, :revoked) }
+
+    it 'is valid' do
+      expect(subject).to be_valid
+    end
+
+    it 'is revoked' do
+      expect(subject).to be_revoked
+    end
+
+    it 'is in the #revoked scope' do
+      expect(Share.revoked).to include(subject)
     end
   end
 end

--- a/spec/models/share_spec.rb
+++ b/spec/models/share_spec.rb
@@ -18,7 +18,6 @@ RSpec.describe Share, type: :model do
       expect(Share.active).to include(subject)
     end
 
-
     it 'can be revoked by a user' do
       account = FactoryBot.create(:user)
       subject.revoke(account)

--- a/spec/request/user_share_spec.rb
+++ b/spec/request/user_share_spec.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'user/SharesController', type: :request do
+  let(:user) { FactoryBot.create(:user) }
+  let(:share) { FactoryBot.create(:share, user: user) }
+  before do
+    share
+    sign_in user
+  end
+  describe '#index' do
+    it 'the index lists the share' do
+      get user_shares_path
+
+      expect(response).to be_successful
+      expect(response.body).to include(share.birth_record.short_name)
+    end
+  end
+  describe '#show' do
+    it 'is displayed' do
+      get user_share_path(share)
+
+      expect(response).to be_successful
+      expect(response.body).to include(share.birth_record.first_and_middle_names)
+      expect(response.body).to include(share.birth_record.family_name)
+    end
+  end
+  describe '#revoke' do
+    it 'can be revoked by the user' do
+      post revoke_user_share_path(share)
+      expect(response).to be_redirect
+
+      share.reload
+      expect(share).to be_revoked
+      expect(share.revoker).to eq(user)
+    end
+  end
+end


### PR DESCRIPTION
Adds a POST action for users to revoke shares they have created. The share is not deleted, it's just flagged as revoked. A `revoked_at` timestamp is set.

This is implemented in the database to allow any user to revoke a share, so that admins, organisations, or the subject of the birth record could be allowed to revoke the share in future. Currently the UI only allows the user who created the share to revoke it.

Currently the UI for users only flags revoked shares by disabling the 'revoke' link, and showing the revoker on the share details page. We probably want to hide revoked shares in the main list and have a history page where revoked shares can be seen.