### PR TITLE
Feature/freeze test data to make percy happy

### DIFF
--- a/spec/feature/user_birth_record_spec.rb
+++ b/spec/feature/user_birth_record_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe 'user/BirthRecordsController', type: :feature do
       end
 
       context 'a target record and some other records exist' do
-        let(:target_birth_record) do
+        let(:target_record) do
           FactoryBot.create(
             :birth_record,
             first_and_middle_names: 'Timmy',

--- a/spec/feature/user_birth_record_spec.rb
+++ b/spec/feature/user_birth_record_spec.rb
@@ -12,7 +12,20 @@ RSpec.describe 'user/BirthRecordsController', type: :feature do
       end
 
       context 'a target record and some other records exist' do
-        let(:target_record) { FactoryBot.create(:birth_record, family_name: 'Target-Person') }
+        let(:target_birth_record) do
+          FactoryBot.create(
+            :birth_record,
+            first_and_middle_names: 'Timmy',
+            family_name: 'Target-Person',
+            date_of_birth: '1979-01-01',
+            place_of_birth: 'Wellington',
+            sex: 'X',
+            parent_first_and_middle_names: 'Daniel',
+            parent_family_name: 'Chuck',
+            other_parent_first_and_middle_names: 'Tameka',
+            other_parent_family_name: 'Senger',
+          )
+        end
         let(:birth_records) { FactoryBot.create_list(:birth_record, 10) }
 
         context 'the required fields are filled in correctly' do

--- a/spec/feature/user_birth_record_spec.rb
+++ b/spec/feature/user_birth_record_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe 'user/BirthRecordsController', type: :feature do
             parent_first_and_middle_names: 'Daniel',
             parent_family_name: 'Chuck',
             other_parent_first_and_middle_names: 'Tameka',
-            other_parent_family_name: 'Senger',
+            other_parent_family_name: 'Senger'
           )
         end
         let(:birth_records) { FactoryBot.create_list(:birth_record, 10) }

--- a/spec/services/birth_record_service_spec.rb
+++ b/spec/services/birth_record_service_spec.rb
@@ -54,7 +54,20 @@ RSpec.describe BirthRecordService do
 
   describe '#query' do
     context 'with a target record and some other records' do
-      let(:target_record) { FactoryBot.create(:birth_record, family_name: 'Target-Person') }
+      let(:target_record) do
+        FactoryBot.create(
+          :birth_record,
+          first_and_middle_names: 'Timmy',
+          family_name: 'Target-Person',
+          date_of_birth: '1979-01-01',
+          place_of_birth: 'Wellington',
+          sex: 'X',
+          parent_first_and_middle_names: 'Daniel',
+          parent_family_name: 'Chuck',
+          other_parent_first_and_middle_names: 'Tameka',
+          other_parent_family_name: 'Senger',
+        )
+      end
       let(:birth_records) { FactoryBot.create_list(:birth_record, 10) }
 
       context 'a query matching the required params' do

--- a/spec/services/birth_record_service_spec.rb
+++ b/spec/services/birth_record_service_spec.rb
@@ -65,7 +65,7 @@ RSpec.describe BirthRecordService do
           parent_first_and_middle_names: 'Daniel',
           parent_family_name: 'Chuck',
           other_parent_first_and_middle_names: 'Tameka',
-          other_parent_family_name: 'Senger',
+          other_parent_family_name: 'Senger'
         )
       end
       let(:birth_records) { FactoryBot.create_list(:birth_record, 10) }


### PR DESCRIPTION
This will stop the thing where Percy flags screenshot differences due to randomly generated test data (for the existing tests, remember this could happen again for new percy screenshots)