### PR TITLE
Proposal: Create demo birth records when a user is registered

### DIFF
--- a/app/controllers/user/registrations_controller.rb
+++ b/app/controllers/user/registrations_controller.rb
@@ -6,17 +6,17 @@ class User::RegistrationsController < Devise::RegistrationsController
   private
 
   def create_family_birth_records
-      # If the registration was rejected, return immediately
-      return unless signed_in?
+    # If the registration was rejected, return immediately
+    return unless signed_in?
 
-      # look for first.last@example.com
-      name_parts = current_user.email.split('@').first.split('.')
-      first_and_middle_names = name_parts.first.capitalize
-      
-      # default to Whanau if no family name was detected
-      family_name = name_parts&.second&.capitalize || 'Whanau'
+    # look for first.last@example.com
+    name_parts = current_user.email.split('@').first.split('.')
+    first_and_middle_names = name_parts.first.capitalize
 
-      DemoDataService.create_birth_record(first_and_middle_names, family_name)
-      DemoDataService.create_family_birth_records(family_name)
+    # default to Whanau if no family name was detected
+    family_name = name_parts&.second&.capitalize || 'Whanau'
+
+    DemoDataService.create_birth_record(first_and_middle_names, family_name)
+    DemoDataService.create_family_birth_records(family_name)
   end
 end

--- a/app/controllers/user/registrations_controller.rb
+++ b/app/controllers/user/registrations_controller.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+class User::RegistrationsController < Devise::RegistrationsController
+  after_action :create_family_birth_records, only: :create
+
+  private
+
+  def create_family_birth_records
+      # If the registration was rejected, return immediately
+      return unless signed_in?
+
+      # look for first.last@example.com
+      name_parts = current_user.email.split('@').first.split('.')
+      first_and_middle_names = name_parts.first.capitalize
+      
+      # default to Whanau if no family name was detected
+      family_name = name_parts&.second&.capitalize || 'Whanau'
+
+      DemoDataService.create_birth_record(first_and_middle_names, family_name)
+      DemoDataService.create_family_birth_records(family_name)
+  end
+end

--- a/app/controllers/user/registrations_controller.rb
+++ b/app/controllers/user/registrations_controller.rb
@@ -1,7 +1,9 @@
 # frozen_string_literal: true
 
 class User::RegistrationsController < Devise::RegistrationsController
+  # rubocop:disable Rails/LexicallyScopedActionFilter
   after_action :create_family_birth_records, only: :create
+  # rubocop:enable Rails/LexicallyScopedActionFilter
 
   private
 

--- a/app/services/demo_data_service.rb
+++ b/app/services/demo_data_service.rb
@@ -28,14 +28,16 @@ class DemoDataService
       :birth_record,
       first_and_middle_names: 'Tama',
       family_name: family_name,
-      date_of_birth: DEFAULT_CHILD_BIRTHDAY
+      date_of_birth: DEFAULT_CHILD_BIRTHDAY,
+      sex: 'Male'
     )
 
     FactoryBot.create(
       :birth_record,
       first_and_middle_names: 'Hine',
       family_name: family_name,
-      date_of_birth: DEFAULT_CHILD_BIRTHDAY
+      date_of_birth: DEFAULT_CHILD_BIRTHDAY,
+      sex: 'Female'
     )
   end
 end

--- a/app/services/demo_data_service.rb
+++ b/app/services/demo_data_service.rb
@@ -1,0 +1,41 @@
+
+# This service provides convenience functions on the application data which
+# shouldn't be allowed in a production application
+class DemoDataService
+
+  DEFAULT_ADULT_BIRTHDAY = Date.parse('1980-01-01').freeze
+  DEFAULT_CHILD_BIRTHDAY = Date.parse('2010-01-01').freeze
+
+  # Creates a birth record for the specified names, born on 1 January 1980 (random sex) so
+  # it's easy to search for
+  def self.create_birth_record(first_and_middle_names, family_name)
+    FactoryBot.create(
+      :birth_record,
+      first_and_middle_names: first_and_middle_names,
+      family_name: family_name,
+      date_of_birth: DEFAULT_ADULT_BIRTHDAY
+    )
+  end
+
+  # Create birth records representing a nuclear family assuming an existing adult:
+  # - 1 additional parent named Matua <family_name> born on 1 January 1980 (random sex) 
+  # - 1 child named Tama <family_name> born on 1 January 2010 (male) 
+  # - 1 child named Hine <family_name> born on 1 January 2010 (female) 
+  def self.create_family_birth_records(family_name)
+    create_birth_record('Matua', family_name)
+
+    FactoryBot.create(
+      :birth_record,
+      first_and_middle_names: 'Tama',
+      family_name: family_name,
+      date_of_birth: DEFAULT_CHILD_BIRTHDAY
+    )
+
+    FactoryBot.create(
+      :birth_record,
+      first_and_middle_names: 'Hine',
+      family_name: family_name,
+      date_of_birth: DEFAULT_CHILD_BIRTHDAY
+    )
+  end
+end

--- a/app/services/demo_data_service.rb
+++ b/app/services/demo_data_service.rb
@@ -1,8 +1,8 @@
+# frozen_string_literal: true
 
 # This service provides convenience functions on the application data which
 # shouldn't be allowed in a production application
 class DemoDataService
-
   DEFAULT_ADULT_BIRTHDAY = Date.parse('1980-01-01').freeze
   DEFAULT_CHILD_BIRTHDAY = Date.parse('2010-01-01').freeze
 
@@ -18,9 +18,9 @@ class DemoDataService
   end
 
   # Create birth records representing a nuclear family assuming an existing adult:
-  # - 1 additional parent named Matua <family_name> born on 1 January 1980 (random sex) 
-  # - 1 child named Tama <family_name> born on 1 January 2010 (male) 
-  # - 1 child named Hine <family_name> born on 1 January 2010 (female) 
+  # - 1 additional parent named Matua <family_name> born on 1 January 1980 (random sex)
+  # - 1 child named Tama <family_name> born on 1 January 2010 (male)
+  # - 1 child named Hine <family_name> born on 1 January 2010 (female)
   def self.create_family_birth_records(family_name)
     create_birth_record('Matua', family_name)
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,7 +12,11 @@ Rails.application.routes.draw do
 
   devise_for :users, path: 'user', controllers: {
     # we need to override the sessions controller, others can be default
-    sessions: 'user/sessions'
+    sessions: 'user/sessions',
+
+    # we want to override the registrations controller so we can create some demo
+    # data for new users to easily find
+    registrations: 'user/registrations'
   }
 
   resources :user, only: [:index]

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -9,6 +9,7 @@
 #   Character.create(name: 'Luke', movie: movies.first)
 
 FactoryBot.create_list :birth_record, 500
+FactoryBot.create_list :organisation_user, 3
 
 ['brenda.wallace', 'ross.patel'].each do |person|
   email = "#{person}@dia.govt.nz"

--- a/spec/feature/user_registration_demo_data_spec.rb
+++ b/spec/feature/user_registration_demo_data_spec.rb
@@ -1,0 +1,167 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'user/registrations_controller', type: :feature do
+  describe '#create' do
+    context 'A User' do
+      let(:user) { FactoryBot.build(:user, email: 'first.last@example.com') }
+
+      context 'after the user registers' do
+        before do
+          visit new_user_registration_path
+
+          fill_in 'user_email', with: user.email
+          fill_in 'user_password', with: user.password
+          fill_in 'user_password_confirmation', with: user.password
+
+          click_on 'Sign up'
+        end
+
+        it 'can find their own demo birth certificate' do
+          visit user_birth_records_path
+          click_link 'Search for Birth Record'
+          fill_in 'birth_record_first_and_middle_names', with: 'First'
+          fill_in 'birth_record_family_name', with: 'Last'
+          fill_in 'birth_record_date_of_birth', with: DemoDataService::DEFAULT_ADULT_BIRTHDAY
+
+          click_on 'Find'
+
+          # look for exactly 1 match, we don't know the record ID though
+          expect(page).to have_css(
+            ".birth-record",
+            count: 1
+          )
+        end
+
+        it 'can find a partner\'s demo birth certificate' do
+          visit user_birth_records_path
+          click_link 'Search for Birth Record'
+          fill_in 'birth_record_first_and_middle_names', with: 'Matua'
+          fill_in 'birth_record_family_name', with: 'Last'
+          fill_in 'birth_record_date_of_birth', with: DemoDataService::DEFAULT_ADULT_BIRTHDAY
+
+          click_on 'Find'
+
+          # look for exactly 1 match, we don't know the record ID though
+          expect(page).to have_css(
+            ".birth-record",
+            count: 1
+          )
+        end
+
+        it 'can find a child\'s demo birth certificate' do
+          visit user_birth_records_path
+          click_link 'Search for Birth Record'
+          fill_in 'birth_record_first_and_middle_names', with: 'Tama'
+          fill_in 'birth_record_family_name', with: 'Last'
+          fill_in 'birth_record_date_of_birth', with: DemoDataService::DEFAULT_CHILD_BIRTHDAY
+
+          click_on 'Find'
+
+          # look for exactly 1 match, we don't know the record ID though
+          expect(page).to have_css(
+            ".birth-record",
+            count: 1
+          )
+        end
+
+        it 'can find another child\'s demo birth certificate' do
+          visit user_birth_records_path
+          click_link 'Search for Birth Record'
+          fill_in 'birth_record_first_and_middle_names', with: 'Hine'
+          fill_in 'birth_record_family_name', with: 'Last'
+          fill_in 'birth_record_date_of_birth', with: DemoDataService::DEFAULT_CHILD_BIRTHDAY
+
+          click_on 'Find'
+
+          # look for exactly 1 match, we don't know the record ID though
+          expect(page).to have_css(
+            ".birth-record",
+            count: 1
+          )
+        end
+      end
+
+      context 'A User with no obvious family name' do
+        let(:user) { FactoryBot.build(:user, email: 'first@example.com') }
+  
+        context 'after the user registers' do
+          before do
+            visit new_user_registration_path
+  
+            fill_in 'user_email', with: user.email
+            fill_in 'user_password', with: user.password
+            fill_in 'user_password_confirmation', with: user.password
+  
+            click_on 'Sign up'
+          end
+  
+          it 'can find their own demo birth certificate with family name Whanau' do
+            visit user_birth_records_path
+            click_link 'Search for Birth Record'
+            fill_in 'birth_record_first_and_middle_names', with: 'First'
+            fill_in 'birth_record_family_name', with: 'Whanau'
+            fill_in 'birth_record_date_of_birth', with: DemoDataService::DEFAULT_ADULT_BIRTHDAY
+  
+            click_on 'Find'
+  
+            # look for exactly 1 match, we don't know the record ID though
+            expect(page).to have_css(
+              ".birth-record",
+              count: 1
+            )
+          end
+  
+          it 'can find a partner\'s demo birth certificate with family name Whanau' do
+            visit user_birth_records_path
+            click_link 'Search for Birth Record'
+            fill_in 'birth_record_first_and_middle_names', with: 'Matua'
+            fill_in 'birth_record_family_name', with: 'Whanau'
+            fill_in 'birth_record_date_of_birth', with: DemoDataService::DEFAULT_ADULT_BIRTHDAY
+  
+            click_on 'Find'
+  
+            # look for exactly 1 match, we don't know the record ID though
+            expect(page).to have_css(
+              ".birth-record",
+              count: 1
+            )
+          end
+  
+          it 'can find a child\'s demo birth certificate with family name Whanau' do
+            visit user_birth_records_path
+            click_link 'Search for Birth Record'
+            fill_in 'birth_record_first_and_middle_names', with: 'Tama'
+            fill_in 'birth_record_family_name', with: 'Whanau'
+            fill_in 'birth_record_date_of_birth', with: DemoDataService::DEFAULT_CHILD_BIRTHDAY
+  
+            click_on 'Find'
+  
+            # look for exactly 1 match, we don't know the record ID though
+            expect(page).to have_css(
+              ".birth-record",
+              count: 1
+            )
+          end
+  
+          it 'can find another child\'s demo birth certificate with family name Whanau' do
+            visit user_birth_records_path
+            click_link 'Search for Birth Record'
+            fill_in 'birth_record_first_and_middle_names', with: 'Hine'
+            fill_in 'birth_record_family_name', with: 'Whanau'
+            fill_in 'birth_record_date_of_birth', with: DemoDataService::DEFAULT_CHILD_BIRTHDAY
+  
+            click_on 'Find'
+  
+            # look for exactly 1 match, we don't know the record ID though
+            expect(page).to have_css(
+              ".birth-record",
+              count: 1
+            )
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/feature/user_registration_demo_data_spec.rb
+++ b/spec/feature/user_registration_demo_data_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe 'user/registrations_controller', type: :feature do
 
           # look for exactly 1 match, we don't know the record ID though
           expect(page).to have_css(
-            ".birth-record",
+            '.birth-record',
             count: 1
           )
         end
@@ -45,7 +45,7 @@ RSpec.describe 'user/registrations_controller', type: :feature do
 
           # look for exactly 1 match, we don't know the record ID though
           expect(page).to have_css(
-            ".birth-record",
+            '.birth-record',
             count: 1
           )
         end
@@ -61,7 +61,7 @@ RSpec.describe 'user/registrations_controller', type: :feature do
 
           # look for exactly 1 match, we don't know the record ID though
           expect(page).to have_css(
-            ".birth-record",
+            '.birth-record',
             count: 1
           )
         end
@@ -77,7 +77,7 @@ RSpec.describe 'user/registrations_controller', type: :feature do
 
           # look for exactly 1 match, we don't know the record ID though
           expect(page).to have_css(
-            ".birth-record",
+            '.birth-record',
             count: 1
           )
         end
@@ -85,78 +85,78 @@ RSpec.describe 'user/registrations_controller', type: :feature do
 
       context 'A User with no obvious family name' do
         let(:user) { FactoryBot.build(:user, email: 'first@example.com') }
-  
+
         context 'after the user registers' do
           before do
             visit new_user_registration_path
-  
+
             fill_in 'user_email', with: user.email
             fill_in 'user_password', with: user.password
             fill_in 'user_password_confirmation', with: user.password
-  
+
             click_on 'Sign up'
           end
-  
+
           it 'can find their own demo birth certificate with family name Whanau' do
             visit user_birth_records_path
             click_link 'Search for Birth Record'
             fill_in 'birth_record_first_and_middle_names', with: 'First'
             fill_in 'birth_record_family_name', with: 'Whanau'
             fill_in 'birth_record_date_of_birth', with: DemoDataService::DEFAULT_ADULT_BIRTHDAY
-  
+
             click_on 'Find'
-  
+
             # look for exactly 1 match, we don't know the record ID though
             expect(page).to have_css(
-              ".birth-record",
+              '.birth-record',
               count: 1
             )
           end
-  
+
           it 'can find a partner\'s demo birth certificate with family name Whanau' do
             visit user_birth_records_path
             click_link 'Search for Birth Record'
             fill_in 'birth_record_first_and_middle_names', with: 'Matua'
             fill_in 'birth_record_family_name', with: 'Whanau'
             fill_in 'birth_record_date_of_birth', with: DemoDataService::DEFAULT_ADULT_BIRTHDAY
-  
+
             click_on 'Find'
-  
+
             # look for exactly 1 match, we don't know the record ID though
             expect(page).to have_css(
-              ".birth-record",
+              '.birth-record',
               count: 1
             )
           end
-  
+
           it 'can find a child\'s demo birth certificate with family name Whanau' do
             visit user_birth_records_path
             click_link 'Search for Birth Record'
             fill_in 'birth_record_first_and_middle_names', with: 'Tama'
             fill_in 'birth_record_family_name', with: 'Whanau'
             fill_in 'birth_record_date_of_birth', with: DemoDataService::DEFAULT_CHILD_BIRTHDAY
-  
+
             click_on 'Find'
-  
+
             # look for exactly 1 match, we don't know the record ID though
             expect(page).to have_css(
-              ".birth-record",
+              '.birth-record',
               count: 1
             )
           end
-  
+
           it 'can find another child\'s demo birth certificate with family name Whanau' do
             visit user_birth_records_path
             click_link 'Search for Birth Record'
             fill_in 'birth_record_first_and_middle_names', with: 'Hine'
             fill_in 'birth_record_family_name', with: 'Whanau'
             fill_in 'birth_record_date_of_birth', with: DemoDataService::DEFAULT_CHILD_BIRTHDAY
-  
+
             click_on 'Find'
-  
+
             # look for exactly 1 match, we don't know the record ID though
             expect(page).to have_css(
-              ".birth-record",
+              '.birth-record',
               count: 1
             )
           end


### PR DESCRIPTION
This is a feature I'm proposing for convenience when demoing feijoa. When a user registers it creates some birth records based on their email address so every user will have some records they can easily find.

When a `User` registers:

  Creates a birth record for the specified names, born on 1 January 1980 (random sex) so
  it's easy to search for

  Create birth records representing a nuclear family assuming an existing adult:
  - 1 additional parent named Matua <family_name> born on 1 January 1980 (random sex) 
  - 1 child named Tama <family_name> born on 1 January 2010 (male) 
  - 1 child named Hine <family_name> born on 1 January 2010 (female) 

Also creates 3 `OrganisationUser`s in `seeds.rb` so there's somebody for users to share with