### PR TITLE
Feature/administrate dashboards

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,3 +83,16 @@ The _Administrate_ dashboards are available at `/admin/` for `admin_user`s.
 The gem is hard coded to use the `/admin/` route which created a conflict with the controllers for the `admin` account type. We resolved this by renaming the `admin` account type to `admin_user` so all those routes are `/admin_user/*`.
 
 Dashboards must be explicitly generated for new models. There is a generator, `rails generate administrate:dashboard Foo`, or see the project documentation for further details. Be aware that the auto-generated dashboards will expose the (encrypted) passwords for users unless you remove those fields from the generated views manually.
+
+You will also need to add new dashboards to `routes.rb`, which will also allow them to appear in the auto-generated navigation. For example:
+```
+namespace :admin do
+  resources :users
+  resources :admin_users
+  resources :organisation_users
+  resources :birth_records
+  resources :shares
+
+  root to: 'birth_records#index'
+end
+```

--- a/README.md
+++ b/README.md
@@ -69,3 +69,17 @@ Start a local server
 ```
 
 Test coverage is reported to `coverage/index.html`
+
+## Gems
+
+### [Administrate](https://github.com/thoughtbot/administrate)
+ > Administrate is a library for Rails apps that automatically generates admin
+ > dashboards. Administrate's admin dashboards give non-technical users clean
+ > interfaces that allow them to create, edit, search, and delete records for
+ > any model in the application.
+
+The _Administrate_ dashboards are available at `/admin/` for `admin_user`s.
+
+The gem is hard coded to use the `/admin/` route which created a conflict with the controllers for the `admin` account type. We resolved this by renaming the `admin` account type to `admin_user` so all those routes are `/admin_user/*`.
+
+Dashboards must be explicitly generated for new models. There is a generator, `rails generate administrate:dashboard Foo`, or see the project documentation for further details. Be aware that the auto-generated dashboards will expose the (encrypted) passwords for users unless you remove those fields from the generated views manually.

--- a/app/controllers/admin/organisation_users_controller.rb
+++ b/app/controllers/admin/organisation_users_controller.rb
@@ -1,0 +1,21 @@
+module Admin
+  class OrganisationUsersController < Admin::ApplicationController
+    # To customize the behavior of this controller,
+    # you can overwrite any of the RESTful actions. For example:
+    #
+    # def index
+    #   super
+    #   @resources = OrganisationUser.
+    #     page(params[:page]).
+    #     per(10)
+    # end
+
+    # Define a custom finder by overriding the `find_resource` method:
+    # def find_resource(param)
+    #   OrganisationUser.find_by!(slug: param)
+    # end
+
+    # See https://administrate-prototype.herokuapp.com/customizing_controller_actions
+    # for more information
+  end
+end

--- a/app/controllers/admin/organisation_users_controller.rb
+++ b/app/controllers/admin/organisation_users_controller.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Admin
   class OrganisationUsersController < Admin::ApplicationController
     # To customize the behavior of this controller,

--- a/app/controllers/admin/shares_controller.rb
+++ b/app/controllers/admin/shares_controller.rb
@@ -1,0 +1,21 @@
+module Admin
+  class SharesController < Admin::ApplicationController
+    # To customize the behavior of this controller,
+    # you can overwrite any of the RESTful actions. For example:
+    #
+    # def index
+    #   super
+    #   @resources = Share.
+    #     page(params[:page]).
+    #     per(10)
+    # end
+
+    # Define a custom finder by overriding the `find_resource` method:
+    # def find_resource(param)
+    #   Share.find_by!(slug: param)
+    # end
+
+    # See https://administrate-prototype.herokuapp.com/customizing_controller_actions
+    # for more information
+  end
+end

--- a/app/controllers/admin/shares_controller.rb
+++ b/app/controllers/admin/shares_controller.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Admin
   class SharesController < Admin::ApplicationController
     # To customize the behavior of this controller,

--- a/app/dashboards/admin_user_dashboard.rb
+++ b/app/dashboards/admin_user_dashboard.rb
@@ -21,7 +21,8 @@ class AdminUserDashboard < Administrate::BaseDashboard
     current_sign_in_ip: Field::String.with_options(searchable: false),
     last_sign_in_ip: Field::String.with_options(searchable: false),
     created_at: Field::DateTime,
-    updated_at: Field::DateTime
+    updated_at: Field::DateTime,
+    password: Field::String
   }.freeze
 
   # COLLECTION_ATTRIBUTES
@@ -32,7 +33,6 @@ class AdminUserDashboard < Administrate::BaseDashboard
   COLLECTION_ATTRIBUTES = %i[
     id
     email
-    reset_password_token
   ].freeze
 
   # SHOW_PAGE_ATTRIBUTES
@@ -65,6 +65,7 @@ class AdminUserDashboard < Administrate::BaseDashboard
     last_sign_in_at
     current_sign_in_ip
     last_sign_in_ip
+    password
   ].freeze
 
   # Overwrite this method to customize how admin users are displayed

--- a/app/dashboards/organisation_user_dashboard.rb
+++ b/app/dashboards/organisation_user_dashboard.rb
@@ -1,4 +1,6 @@
-require "administrate/base_dashboard"
+# frozen_string_literal: true
+
+require 'administrate/base_dashboard'
 
 class OrganisationUserDashboard < Administrate::BaseDashboard
   # ATTRIBUTE_TYPES
@@ -19,7 +21,7 @@ class OrganisationUserDashboard < Administrate::BaseDashboard
     current_sign_in_ip: Field::String.with_options(searchable: false),
     last_sign_in_ip: Field::String.with_options(searchable: false),
     created_at: Field::DateTime,
-    updated_at: Field::DateTime,
+    updated_at: Field::DateTime
   }.freeze
 
   # COLLECTION_ATTRIBUTES
@@ -27,42 +29,42 @@ class OrganisationUserDashboard < Administrate::BaseDashboard
   #
   # By default, it's limited to four items to reduce clutter on index pages.
   # Feel free to add, remove, or rearrange items.
-  COLLECTION_ATTRIBUTES = [
-    :shares,
-    :id,
-    :email,
+  COLLECTION_ATTRIBUTES = %i[
+    shares
+    id
+    email
   ].freeze
 
   # SHOW_PAGE_ATTRIBUTES
   # an array of attributes that will be displayed on the model's show page.
-  SHOW_PAGE_ATTRIBUTES = [
-    :shares,
-    :id,
-    :email,
-    :reset_password_sent_at,
-    :remember_created_at,
-    :sign_in_count,
-    :current_sign_in_at,
-    :last_sign_in_at,
-    :current_sign_in_ip,
-    :last_sign_in_ip,
-    :created_at,
-    :updated_at,
+  SHOW_PAGE_ATTRIBUTES = %i[
+    shares
+    id
+    email
+    reset_password_sent_at
+    remember_created_at
+    sign_in_count
+    current_sign_in_at
+    last_sign_in_at
+    current_sign_in_ip
+    last_sign_in_ip
+    created_at
+    updated_at
   ].freeze
 
   # FORM_ATTRIBUTES
   # an array of attributes that will be displayed
   # on the model's form (`new` and `edit`) pages.
-  FORM_ATTRIBUTES = [
-    :shares,
-    :email,
-    :reset_password_sent_at,
-    :remember_created_at,
-    :sign_in_count,
-    :current_sign_in_at,
-    :last_sign_in_at,
-    :current_sign_in_ip,
-    :last_sign_in_ip,
+  FORM_ATTRIBUTES = %i[
+    shares
+    email
+    reset_password_sent_at
+    remember_created_at
+    sign_in_count
+    current_sign_in_at
+    last_sign_in_at
+    current_sign_in_ip
+    last_sign_in_ip
   ].freeze
 
   # Overwrite this method to customize how organisation users are displayed

--- a/app/dashboards/organisation_user_dashboard.rb
+++ b/app/dashboards/organisation_user_dashboard.rb
@@ -1,0 +1,74 @@
+require "administrate/base_dashboard"
+
+class OrganisationUserDashboard < Administrate::BaseDashboard
+  # ATTRIBUTE_TYPES
+  # a hash that describes the type of each of the model's fields.
+  #
+  # Each different type represents an Administrate::Field object,
+  # which determines how the attribute is displayed
+  # on pages throughout the dashboard.
+  ATTRIBUTE_TYPES = {
+    shares: Field::HasMany,
+    id: Field::Number,
+    email: Field::String,
+    reset_password_sent_at: Field::DateTime,
+    remember_created_at: Field::DateTime,
+    sign_in_count: Field::Number,
+    current_sign_in_at: Field::DateTime,
+    last_sign_in_at: Field::DateTime,
+    current_sign_in_ip: Field::String.with_options(searchable: false),
+    last_sign_in_ip: Field::String.with_options(searchable: false),
+    created_at: Field::DateTime,
+    updated_at: Field::DateTime,
+  }.freeze
+
+  # COLLECTION_ATTRIBUTES
+  # an array of attributes that will be displayed on the model's index page.
+  #
+  # By default, it's limited to four items to reduce clutter on index pages.
+  # Feel free to add, remove, or rearrange items.
+  COLLECTION_ATTRIBUTES = [
+    :shares,
+    :id,
+    :email,
+  ].freeze
+
+  # SHOW_PAGE_ATTRIBUTES
+  # an array of attributes that will be displayed on the model's show page.
+  SHOW_PAGE_ATTRIBUTES = [
+    :shares,
+    :id,
+    :email,
+    :reset_password_sent_at,
+    :remember_created_at,
+    :sign_in_count,
+    :current_sign_in_at,
+    :last_sign_in_at,
+    :current_sign_in_ip,
+    :last_sign_in_ip,
+    :created_at,
+    :updated_at,
+  ].freeze
+
+  # FORM_ATTRIBUTES
+  # an array of attributes that will be displayed
+  # on the model's form (`new` and `edit`) pages.
+  FORM_ATTRIBUTES = [
+    :shares,
+    :email,
+    :reset_password_sent_at,
+    :remember_created_at,
+    :sign_in_count,
+    :current_sign_in_at,
+    :last_sign_in_at,
+    :current_sign_in_ip,
+    :last_sign_in_ip,
+  ].freeze
+
+  # Overwrite this method to customize how organisation users are displayed
+  # across all pages of the admin dashboard.
+  #
+  # def display_resource(organisation_user)
+  #   "OrganisationUser ##{organisation_user.id}"
+  # end
+end

--- a/app/dashboards/organisation_user_dashboard.rb
+++ b/app/dashboards/organisation_user_dashboard.rb
@@ -21,7 +21,8 @@ class OrganisationUserDashboard < Administrate::BaseDashboard
     current_sign_in_ip: Field::String.with_options(searchable: false),
     last_sign_in_ip: Field::String.with_options(searchable: false),
     created_at: Field::DateTime,
-    updated_at: Field::DateTime
+    updated_at: Field::DateTime,
+    password: Field::String
   }.freeze
 
   # COLLECTION_ATTRIBUTES
@@ -65,6 +66,7 @@ class OrganisationUserDashboard < Administrate::BaseDashboard
     last_sign_in_at
     current_sign_in_ip
     last_sign_in_ip
+    password
   ].freeze
 
   # Overwrite this method to customize how organisation users are displayed

--- a/app/dashboards/share_dashboard.rb
+++ b/app/dashboards/share_dashboard.rb
@@ -1,0 +1,69 @@
+require "administrate/base_dashboard"
+
+class ShareDashboard < Administrate::BaseDashboard
+  # ATTRIBUTE_TYPES
+  # a hash that describes the type of each of the model's fields.
+  #
+  # Each different type represents an Administrate::Field object,
+  # which determines how the attribute is displayed
+  # on pages throughout the dashboard.
+  ATTRIBUTE_TYPES = {
+    user: Field::BelongsTo,
+    recipient: Field::Polymorphic,
+    birth_record: Field::BelongsTo,
+    id: Field::Number,
+    created_at: Field::DateTime,
+    updated_at: Field::DateTime,
+    revoked_by_type: Field::String,
+    revoked_by_id: Field::Number,
+    revoked_at: Field::DateTime,
+    last_accessed_at: Field::DateTime,
+  }.freeze
+
+  # COLLECTION_ATTRIBUTES
+  # an array of attributes that will be displayed on the model's index page.
+  #
+  # By default, it's limited to four items to reduce clutter on index pages.
+  # Feel free to add, remove, or rearrange items.
+  COLLECTION_ATTRIBUTES = [
+    :user,
+    :recipient,
+    :birth_record,
+    :id,
+  ].freeze
+
+  # SHOW_PAGE_ATTRIBUTES
+  # an array of attributes that will be displayed on the model's show page.
+  SHOW_PAGE_ATTRIBUTES = [
+    :user,
+    :recipient,
+    :birth_record,
+    :id,
+    :created_at,
+    :updated_at,
+    :revoked_by_type,
+    :revoked_by_id,
+    :revoked_at,
+    :last_accessed_at,
+  ].freeze
+
+  # FORM_ATTRIBUTES
+  # an array of attributes that will be displayed
+  # on the model's form (`new` and `edit`) pages.
+  FORM_ATTRIBUTES = [
+    :user,
+    :recipient,
+    :birth_record,
+    :revoked_by_type,
+    :revoked_by_id,
+    :revoked_at,
+    :last_accessed_at,
+  ].freeze
+
+  # Overwrite this method to customize how shares are displayed
+  # across all pages of the admin dashboard.
+  #
+  # def display_resource(share)
+  #   "Share ##{share.id}"
+  # end
+end

--- a/app/dashboards/share_dashboard.rb
+++ b/app/dashboards/share_dashboard.rb
@@ -1,4 +1,6 @@
-require "administrate/base_dashboard"
+# frozen_string_literal: true
+
+require 'administrate/base_dashboard'
 
 class ShareDashboard < Administrate::BaseDashboard
   # ATTRIBUTE_TYPES
@@ -17,7 +19,7 @@ class ShareDashboard < Administrate::BaseDashboard
     revoked_by_type: Field::String,
     revoked_by_id: Field::Number,
     revoked_at: Field::DateTime,
-    last_accessed_at: Field::DateTime,
+    last_accessed_at: Field::DateTime
   }.freeze
 
   # COLLECTION_ATTRIBUTES
@@ -25,39 +27,39 @@ class ShareDashboard < Administrate::BaseDashboard
   #
   # By default, it's limited to four items to reduce clutter on index pages.
   # Feel free to add, remove, or rearrange items.
-  COLLECTION_ATTRIBUTES = [
-    :user,
-    :recipient,
-    :birth_record,
-    :id,
+  COLLECTION_ATTRIBUTES = %i[
+    user
+    recipient
+    birth_record
+    id
   ].freeze
 
   # SHOW_PAGE_ATTRIBUTES
   # an array of attributes that will be displayed on the model's show page.
-  SHOW_PAGE_ATTRIBUTES = [
-    :user,
-    :recipient,
-    :birth_record,
-    :id,
-    :created_at,
-    :updated_at,
-    :revoked_by_type,
-    :revoked_by_id,
-    :revoked_at,
-    :last_accessed_at,
+  SHOW_PAGE_ATTRIBUTES = %i[
+    user
+    recipient
+    birth_record
+    id
+    created_at
+    updated_at
+    revoked_by_type
+    revoked_by_id
+    revoked_at
+    last_accessed_at
   ].freeze
 
   # FORM_ATTRIBUTES
   # an array of attributes that will be displayed
   # on the model's form (`new` and `edit`) pages.
-  FORM_ATTRIBUTES = [
-    :user,
-    :recipient,
-    :birth_record,
-    :revoked_by_type,
-    :revoked_by_id,
-    :revoked_at,
-    :last_accessed_at,
+  FORM_ATTRIBUTES = %i[
+    user
+    recipient
+    birth_record
+    revoked_by_type
+    revoked_by_id
+    revoked_at
+    last_accessed_at
   ].freeze
 
   # Overwrite this method to customize how shares are displayed

--- a/app/dashboards/user_dashboard.rb
+++ b/app/dashboards/user_dashboard.rb
@@ -22,7 +22,8 @@ class UserDashboard < Administrate::BaseDashboard
     current_sign_in_ip: Field::String.with_options(searchable: false),
     last_sign_in_ip: Field::String.with_options(searchable: false),
     created_at: Field::DateTime,
-    updated_at: Field::DateTime
+    updated_at: Field::DateTime,
+    password: Field::String
   }.freeze
 
   # COLLECTION_ATTRIBUTES
@@ -68,6 +69,7 @@ class UserDashboard < Administrate::BaseDashboard
     last_sign_in_at
     current_sign_in_ip
     last_sign_in_ip
+    password
   ].freeze
 
   # Overwrite this method to customize how users are displayed

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,9 +5,11 @@ Rails.application.routes.draw do
   namespace :admin do
     resources :users
     resources :admin_users
+    resources :organisation_users
     resources :birth_records
+    resources :shares
 
-    root to: 'users#index'
+    root to: 'birth_records#index'
   end
 
   devise_for :users, path: 'user', controllers: {


### PR DESCRIPTION
Adds _Administrate_ dashboards for `OrganisationUser`s and `Share`s, and lets you set/update the password for all user types (so you can create organisations from the admin interface now)

Added info to the Readme describing what _Administrate_ is used for