### PR TITLE
Auto corrected by following Lint Ruby Layout/TrailingWhitespace

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,7 +3,7 @@
 # rubocop:disable Metrics/BlockLength
 Rails.application.routes.draw do
   resources :organisations, only: [:index]
-  
+
   namespace :admin do
     resources :users
     resources :admin_users


### PR DESCRIPTION
Auto corrected by following Lint Ruby Layout/TrailingWhitespace

Click [here](https://awesomecode.io/repos/ServiceInnovationLab/feijoa/ruby_lint_configs/42681) to configure it on awesomecode.io