### PR TITLE
Respond to requests with a document

### DIFF
--- a/app/assets/stylesheets/_bootstrap_overrides.scss
+++ b/app/assets/stylesheets/_bootstrap_overrides.scss
@@ -34,6 +34,12 @@ h1, h2, h5 {
     justify-content: space-around;
   }
 }
+
+.card--request {
+  background-color: mix($grey, #FFF, 50);
+  color: mix(#000, #FFF, 70);
+}
+
 @include media-breakpoint-down(sm) {
   .navbar {
     font-size: 0.8em;
@@ -42,4 +48,19 @@ h1, h2, h5 {
 
 label.required:after {
   content:" *";
+}
+
+.badge {
+  &--cancelled, &--declined {
+    @extend .badge-danger;
+  }
+  &--initiated {
+    @extend .badge-primary;
+  }
+  &--received {
+    @extend .badge-info;
+  }
+  &--resolved {
+    @extend .badge-success;
+  }
 }

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -14,7 +14,6 @@
 @import 'variables';
 @import 'bootstrap';
 @import 'rails_bootstrap_forms';
-@import 'badge';
 @import 'bootstrap_overrides';
 
 @import 'body';

--- a/app/assets/stylesheets/badge.scss
+++ b/app/assets/stylesheets/badge.scss
@@ -1,4 +1,0 @@
-.badge--account-type {
-  @extend .badge-primary;
-  font-size: 150%;
-}

--- a/app/controllers/organisation_member/dashboard_controller.rb
+++ b/app/controllers/organisation_member/dashboard_controller.rb
@@ -4,5 +4,7 @@ class OrganisationMember::DashboardController < OrganisationMember::BaseControll
   # GET
   def index
     authorize @organisation, :dashboard?
+    @shares = @organisation.shares.order(updated_at: :desc)
+    @requests = @organisation.requests.order(updated_at: :desc)
   end
 end

--- a/app/controllers/user/requests_controller.rb
+++ b/app/controllers/user/requests_controller.rb
@@ -2,7 +2,7 @@
 
 class User::RequestsController < User::BaseController
   respond_to :html
-  before_action :set_request, only: %i[show decline]
+  before_action :set_request, only: %i[show respond decline]
   responders :flash
 
   # GET /requests
@@ -24,10 +24,42 @@ class User::RequestsController < User::BaseController
     render :show
   end
 
+  # POST /requests/1/respond
+  def respond
+    authorize @request, :respond?
+    document = current_user.documents(type: response_params[:document_type])
+                           .find_by(id: response_params[:document_id])
+    share = create_share(document)
+
+    if share.save
+      @request.update_attributes(share_id: share.id)
+      @request.respond
+      flash.now[:notice] = 'You have shared this document.'
+    else
+      flash.now[:alert] = 'There was a problem sharing this document. Please try again.'
+    end
+    render :show
+  end
+
   private
 
   # Set the request, if it exists and is available to the current user
   def set_request
     @request = current_user.requests.find(params[:id])
+  end
+
+  def response_params
+    params.permit(:document_id, :document_type)
+  end
+
+  def create_share(document)
+    existing_share = Share.find_by(user: current_user, recipient: @request.requester, birth_record: document)
+    return existing_share if existing_share.present?
+
+    AuditedOperationsService.share_birth_record_with_recipient(
+      user: current_user,
+      birth_record: document,
+      recipient: @request.requester
+    )
   end
 end

--- a/app/models/request.rb
+++ b/app/models/request.rb
@@ -7,6 +7,7 @@ class Request < ApplicationRecord
   belongs_to :requestee, class_name: 'User',
                          inverse_of: :requests, foreign_key: 'requestee_id',
                          dependent: :destroy
+  belongs_to :share, required: false
 
   validates :requester, presence: true
   validates :requestee, presence: true
@@ -24,17 +25,16 @@ class Request < ApplicationRecord
       transition initiated: :received
     end
     event :respond do
-      transition received: :responded
+      transition initiated: :resolved
+      transition received: :resolved
     end
     event :decline do
       transition initiated: :declined
       transition received: :declined
-      transition responded: :declined
     end
     event :cancel do
       transition initiated: :cancelled
       transition received: :cancelled
-      transition responded: :cancelled
     end
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -44,8 +44,11 @@ class User < ApplicationRecord
     organisations.include? organisation
   end
 
-  def documents
-    birth_records
+  def documents(type: BirthRecord::DOCUMENT_TYPE)
+    return birth_records if type.to_s == BirthRecord::DOCUMENT_TYPE
+
+    # one day there will be other types of documents, but for the moment...
+    []
   end
 
   # Get the audits for this user

--- a/app/policies/request_policy.rb
+++ b/app/policies/request_policy.rb
@@ -16,6 +16,10 @@ class RequestPolicy
     user == request.requestee
   end
 
+  def respond?
+    user == request.requestee
+  end
+
   def cancel?
     user.member_of?(request.requester)
   end

--- a/app/views/organisation_member/dashboard/index.html.erb
+++ b/app/views/organisation_member/dashboard/index.html.erb
@@ -1,29 +1,31 @@
 <%= content_for :subhead do %>
   <%= render partial: "organisation_member/shared/subhead" %>
 <% end %>
-<h1><%= @organisation.name %></h1>
-<section class="c-dashboard-links">
+<h1><%= @organisation.name %>'s documents dashboard</h1>
+<p class="lead">This is where your documents are stored. This is where you can request documents, view them, or remove your access to them.</p>
+
+<section  class="mt-4">
+  <h3>Request a document</h3>
   <div class="row">
-    <div class="col-4">
-      <%= link_to organisation_member_shares_path(@organisation) do %>
-        <div class="c-dashboard-links__link card">
-          <div class="card-body">
-              Documents shared with <%=@organisation.name %>
-          </div>
-        </div>
-      <% end %>
-    </div>
-    <div class="col-4">
-      <%= link_to organisation_member_requests_path(@organisation) do %>
-        <div class="c-dashboard-links__link card">
-          <div class="card-body">
-              Requests for documents to be shared with <%=@organisation.name %>
-          </div>
-        </div>
-      <% end %>
-      <%= link_to new_organisation_member_request_path(@organisation), class: 'add-doc' do %>
-        <%= image_tag("plus.svg", alt: 'Add a new request') %>
-      <% end %>
-    </div>
+    <% @requests.each do |request| %>
+      <div class="col-sm-4 mb-4">
+        <%= render partial: 'organisation_member/requests/request', locals: { request: request } %>
+      </div>
+    <% end %>
+  </div>
+  <%= link_to new_organisation_member_request_path(@organisation), class: 'add-doc' do %>
+    <%= image_tag("plus.svg", alt: 'Add a new request') %>
+  <% end %>
+</section>
+<section class="shares mt-4">
+  <h3>Received documents</h3>
+  <div class="row">
+    <% @shares.each do |share| %>
+      <div class="col-sm-4 mb-4">
+        <%= render partial: 'shared/documents/preview', locals: { document: share.birth_record, shared_by: share.user.email, actions: [
+          { title: 'View', link: organisation_member_share_path(@organisation, share), button_class: 'secondary' }
+          ]} %>
+      </div>
+    <% end %>
   </div>
 </section>

--- a/app/views/organisation_member/requests/_request.html.erb
+++ b/app/views/organisation_member/requests/_request.html.erb
@@ -1,24 +1,21 @@
-<div class="card">
-  <div class="card-header">
-    <h3>Request for <%= t("documents.document_type.#{request.document_type}") %></h3>
-    <dd><%= time_ago_in_words(request.created_at) %></dd>
-  </div>
+<div class="card card--with-fancy-footer card--request">
   <div class="card-body">
-    <strong>To <%= request.requestee.email %>:</strong>
-    <blockquote class="blockquote ">
-      <%= request.note %>
-    </blockquote>
-    <hr>
-    <dl>
-      <dt>State</dt>
-      <dd><%= request.state %></dd>
-    </dl>
+    <div class="d-flex justify-content-between">
+      <h5 class="card-title"><%= t("documents.types.#{request.document_type}") %></h5>
+      <div>
+        <span class="badge badge--<%= request.state %>"><%= request.state %></span>
+      </div>
+    </div>
+    <p>Requested from <%= request.requestee.email %></p>
   </div>
   <div class="card-footer">
-    <% if request.can_cancel? %>
-      <%= form_with(url: cancel_organisation_member_request_path(@organisation, request), method: "post", local: true) do %>
-        <%= submit_tag("Cancel", class: 'btn btn-danger') %>
+    <div class="card-footer__inner">
+      <%= link_to "View", organisation_member_request_path(@organisation, request), class: "btn btn-secondary" %>
+      <% if request.can_cancel? %>
+        <%= form_with(url: cancel_organisation_member_request_path(@organisation, request), method: "post", local: true) do %>
+          <%= submit_tag("Cancel", class: 'btn btn-danger') %>
+        <% end %>
       <% end %>
-    <% end %>
+    </div>
   </div>
 </div>

--- a/app/views/organisation_member/requests/show.html.erb
+++ b/app/views/organisation_member/requests/show.html.erb
@@ -1,6 +1,11 @@
 <%= content_for :subhead do %>
   <%= render partial: "organisation_member/shared/subhead" %>
 <% end %>
+
+<div class="mb-4">
+  <%= link_to "← Back", organisation_member_dashboard_path(@organisation), class: 'text-dark' %>
+</div>
+
 <h1>Request for a document to be shared with <%= @organisation.name %></h1>
 
 <dt>Requester</dt>
@@ -23,6 +28,14 @@
 <dd>
   <%= t("documents.types.#{@request.document_type}") %>
 </dd>
+<% if @request.share.present? %>
+  <dt>Shared document</dt>
+  <%= render partial: 'shared/documents/preview', locals: { document: @request.share.birth_record , actions: [
+    link: organisation_member_share_path(@organisation, @request.share),
+    button_class: 'secondary',
+    title: 'View'
+  ]} %>
+<% end %>
 <% if @request.can_cancel? %>
   <%= form_with(url: cancel_organisation_member_request_path(@organisation, @request), method: "post", local: true) do %>
     <%= submit_tag("Cancel", class: 'btn btn-danger') %>

--- a/app/views/organisation_member/shares/show.html.erb
+++ b/app/views/organisation_member/shares/show.html.erb
@@ -1,6 +1,11 @@
 <%= content_for :subhead do %>
   <%= render partial: "organisation_member/shared/subhead" %>
 <% end %>
+
+<div class="mb-4">
+  <%= link_to "← Back", organisation_member_dashboard_path(@organisation), class: 'text-dark' %>
+</div>
+
 <h1>Shared document</h1>
 <p class="lead"><%= @share.user.email %> has shared this with you.</p>
 <p>
@@ -17,5 +22,3 @@
   <strong>Recipient:</strong>
   <%= @share.recipient.name %>
 </p>
-
-<%= link_to 'Back', organisation_member_shares_path %>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -31,6 +31,7 @@
           <div class="dropdown-menu" aria-labelledby="userDropdown">
             <%= link_to 'My Documents', user_birth_records_path, class: 'dropdown-item' %>
             <%= link_to 'My Shares', user_shares_path, class: 'dropdown-item' %>
+            <%= link_to 'Requests', user_requests_path, class: 'dropdown-item' %>
             <%= link_to 'History', user_audits_path, class: 'dropdown-item' %>
           </div>
           <div class="dropdown-menu" aria-labelledby="navbarDropdown">

--- a/app/views/shared/documents/_preview.html.erb
+++ b/app/views/shared/documents/_preview.html.erb
@@ -2,11 +2,20 @@
     <div class="card-body">
       <h5 class="card-title"><%= t("documents.types.#{document.document_type}") %></h5>
       <p><%= document.heading %></p>
+      <% if local_assigns[:shared_by] %>
+        <p>Shared by <%= shared_by %></p>
+      <% end %>
     </div>
   <div class="card-footer">
     <div class="card-footer__inner d-flex justify-content-around">
       <% actions.each do |action| %>
-        <%= link_to action[:title], action[:link], class: "btn btn-#{action[:button_class]}" %>
+        <% if action[:form] %>
+          <%= form_with(url: action[:link], method: action[:method] || "post", local: action[:local] || "true") do %>
+            <%= submit_tag(action[:title], class: "btn btn-#{action[:button_class]}") %>
+          <% end %>
+        <% else %>
+          <%= link_to action[:title], action[:link], class: "btn btn-#{action[:button_class]}" %>
+        <% end %>
       <% end %>
     </div>
   </div>

--- a/app/views/user/requests/_request.html.erb
+++ b/app/views/user/requests/_request.html.erb
@@ -1,17 +1,32 @@
 <div class="card">
   <div class="card-header">
-    <h3>Request for <%= t("documents.document_type.#{request.document_type}") %></h3>
+    <h3>Request for <%= t("documents.types.#{request.document_type}") %></h3>
   </div>
   <div class="card-body">
-    <strong>From <%= request.requester.name %>:</strong>
-    <blockquote class="blockquote ">
-      <%= request.note %>
-    </blockquote>
+    <p>
+      <%= request.requester.name %> sent this request for a <%= t("documents.types.#{request.document_type}").downcase %> <%= time_ago_in_words(request.created_at) %> ago.
+    </p>
+    <% if request.note %>
+      <blockquote class="blockquote ">
+        <%= request.note %>
+      </blockquote>
+      <% end %>
     <hr>
   </div>
   <div class="card-footer">
-    <%= form_with(url: decline_user_request_path(request), method: "post", local: true) do %>
-      <%= submit_tag("Decline request", class: 'btn btn-danger') %>
-    <% end %>
+    <div class="d-flex justify-content-between">
+      <% if request.can_decline? %>
+        <%= form_with(url: decline_user_request_path(request), method: "post", local: true) do %>
+          <%= submit_tag("Decline", class: 'btn btn-danger') %>
+        <% end %>
+      <% end %>
+      <%= link_to "View", user_request_path(request), class: 'btn btn-secondary' %>
+      <% if request.can_respond? %>
+        <a href="#" id="add-record" data-toggle="modal" data-target="#modalBirthRecordForm" class="btn btn-primary">
+          Respond
+        </a>
+        <%= render partial: 'user/requests/response_modal', locals: { request: request } %>
+      <% end %>
+    </div>
   </div>
 </div>

--- a/app/views/user/requests/_response_modal.html.erb
+++ b/app/views/user/requests/_response_modal.html.erb
@@ -1,0 +1,35 @@
+<div class="modal fade" id="modalBirthRecordForm" tabindex="-1" role="dialog" aria-hidden="true">
+  <div class="modal-dialog" role="document">
+    <div class="modal-content">
+      <div class="modal-header text-center">
+        <h4 class="modal-title w-100">Respond to request</h4>
+        <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+          <span aria-hidden="true">&times;</span>
+        </button>
+      </div>
+      <div class="modal-body mx-3">
+        <section class="request-details">
+          <%= request.requester.name %> has requested a <%= t("document.type.#{request.document_type}") %> from you.
+          <blockquote class="blockquote"><%= request.note %></blockquote>
+        </section>
+        <section>
+          <% if current_user.documents(type: request.document_type).any? %>
+            <h2>Select a document to share</h2>
+            <% current_user.documents(type: request.document_type).each do |document| %>
+              <div class="mb-2">
+                <%= render partial: 'shared/documents/preview', locals: { document: document, actions: [
+                  {
+                    form: true,
+                    link: respond_user_request_path(request.id, document_id: document.id, document_type: request.document_type),
+                    title: 'Share',
+                    button_class: 'primary'
+                  }
+                ] } %>
+              </div>
+            <% end %>
+          <% end %>
+        </section>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/user/requests/index.html.erb
+++ b/app/views/user/requests/index.html.erb
@@ -1,7 +1,7 @@
 <h1>Document requests</h1>
 <div class="row mb-4">
-  <% @requests.each do |request| %>
-  <div class="col-4">
+  <% @requests.order(updated_at: :desc).each do |request| %>
+  <div class="col-4 mb-4">
     <div class="card">
       <div class="card-header">
         <h3 class="card-title">
@@ -33,9 +33,16 @@
           </dd>
           <dt>Document type</dt>
           <dd>
-            <%= t("documents.types.#{request.document_type}") %>            
+            <%= t("documents.types.#{request.document_type}") %>
           </dd>
         </dl>
+        <% if request.share.present? %>
+          <%= render partial: 'shared/documents/preview', locals: { document: request.share.birth_record , actions: [
+            link: user_birth_record_path(request.share.birth_record),
+            button_class: 'secondary',
+            title: 'View'
+          ]} %>
+        <% end %>
       </div>
     </div>
   </div>

--- a/app/views/user/requests/show.html.erb
+++ b/app/views/user/requests/show.html.erb
@@ -24,3 +24,23 @@
 <dd>
   <%= t("documents.types.#{@request.document_type}") %>
 </dd>
+<% if @request.share.present? %>
+  <dd>Shared document</dd>
+  <%= render partial: 'shared/documents/preview', locals: { document: @request.share.birth_record , actions: [
+    link: user_birth_record_path(@request.share.birth_record),
+    button_class: 'secondary',
+    title: 'View'
+  ]} %>
+<% end %>
+<% if @request.can_decline? %>
+  <%= form_with(url: decline_user_request_path(@request), method: "post", local: true) do %>
+    <%= submit_tag("Decline", class: 'btn btn-danger') %>
+  <% end %>
+<% end %>
+<% if @request.can_respond? %>
+  <a href="#" id="add-record" data-toggle="modal" data-target="#modalBirthRecordForm" class="btn btn-primary">
+    Respond
+  </a>
+  <%= render partial: 'user/requests/response_modal', locals: { request: @request } %>
+<% end %>
+</div>

--- a/spec/models/request_spec.rb
+++ b/spec/models/request_spec.rb
@@ -12,10 +12,10 @@ RSpec.describe Request, type: :model do
   end
 
   describe 'Request#unresolved' do
-    it 'includes initiated and received requests but not cancelled, declined or responded ones' do
+    it 'includes initiated and received requests but not cancelled, declined or resolved ones' do
       FactoryBot.create(:request, state: :cancelled)
       FactoryBot.create(:request, state: :declined)
-      FactoryBot.create(:request, state: :responded)
+      FactoryBot.create(:request, state: :resolved)
       initiated_request = FactoryBot.create(:request, state: :initiated)
       received_request = FactoryBot.create(:request, state: :received)
 


### PR DESCRIPTION
Branched off #146.

Implements:

- A request recipient sees documents of the requested type that they have already added.
- A request recipient can select a document of the requested type and share it with the request sender.
- A request sender can see the shared document in response.
- Tidies up the dashboards a little, using Ross's designs.

Does not implement:

- A request recipient is prompted to add new documents of the requested type if they have not added any.