### PR TITLE
📑 Allow for multiple document types

### DIFF
--- a/app/controllers/admin/user_documents_controller.rb
+++ b/app/controllers/admin/user_documents_controller.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module Admin
+  class UserDocumentsController < Admin::ApplicationController
+    # To customize the behavior of this controller,
+    # you can overwrite any of the RESTful actions. For example:
+    #
+    # def index
+    #   super
+    #   @resources = Share.
+    #     page(params[:page]).
+    #     per(10)
+    # end
+
+    # Define a custom finder by overriding the `find_resource` method:
+    # def find_resource(param)
+    #   Share.find_by!(slug: param)
+    # end
+
+    # See https://administrate-prototype.herokuapp.com/customizing_controller_actions
+    # for more information
+  end
+end

--- a/app/controllers/organisation_member/shares_controller.rb
+++ b/app/controllers/organisation_member/shares_controller.rb
@@ -10,10 +10,7 @@ class OrganisationMember::SharesController < OrganisationMember::BaseController
 
   # GET /shares/1
   def show
-    @official_birth_record = AuditedOperationsService.access_shared_birth_record(
-      logged_identity: current_account,
-      share: @share
-    )
+    @official_birth_record = @share.access(accessed_by: current_account)
   end
 
   private

--- a/app/controllers/user/birth_records_controller.rb
+++ b/app/controllers/user/birth_records_controller.rb
@@ -26,10 +26,8 @@ class User::BirthRecordsController < User::BaseController
   # Attempts to add a record which is already attached will be ignored (by
   # 'distinct' modifier on User.birth_records).
   def add
-    AuditedOperationsService.add_birth_record_to_user(
-      user: current_user,
-      birth_record: BirthRecord.find_by(params.permit(:id))
-    )
+    @birth_record = BirthRecord.find_by(params.permit(:id))
+    @birth_record&.add_to(current_user)
 
     redirect_to user_birth_records_path
   end
@@ -39,10 +37,8 @@ class User::BirthRecordsController < User::BaseController
   # Attempts to remove a record which is not attached or doesn't exist will be
   # silently ignored.
   def remove
-    AuditedOperationsService.remove_birth_record_from_user(
-      user: current_user,
-      birth_record_id: params.permit(:id)[:id].to_i
-    )
+    @birth_record = current_user.birth_records.find_by(params.permit(:id))
+    @birth_record&.remove_from(current_user)
 
     redirect_to user_birth_records_path
   end

--- a/app/controllers/user/requests_controller.rb
+++ b/app/controllers/user/requests_controller.rb
@@ -58,6 +58,6 @@ class User::RequestsController < User::BaseController
     existing_share = Share.find_by(user: current_user, recipient: @request.requester, document: document)
     return existing_share if existing_share.present?
 
-    document.share(user: current_user, recipient: @request.requester)
+    document.share_with(user: current_user, recipient: @request.requester)
   end
 end

--- a/app/controllers/user/requests_controller.rb
+++ b/app/controllers/user/requests_controller.rb
@@ -55,13 +55,9 @@ class User::RequestsController < User::BaseController
   end
 
   def find_or_create_share(document)
-    existing_share = Share.find_by(user: current_user, recipient: @request.requester, birth_record: document)
+    existing_share = Share.find_by(user: current_user, recipient: @request.requester, document: document)
     return existing_share if existing_share.present?
 
-    AuditedOperationsService.share_birth_record_with_recipient(
-      user: current_user,
-      birth_record: document,
-      recipient: @request.requester
-    )
+    document.share(user: current_user, recipient: @request.requester)
   end
 end

--- a/app/controllers/user/shares_controller.rb
+++ b/app/controllers/user/shares_controller.rb
@@ -48,7 +48,7 @@ class User::SharesController < User::BaseController
 
   def create_share_with_auditing
     birth_record = current_user.birth_records.find_by(id: share_params['document_id'])
-    birth_record.share(user: current_user, recipient: Organisation.find_by(id: share_params['recipient_id']))
+    birth_record.share_with(recipient: Organisation.find_by(id: share_params['recipient_id']), user: current_user)
   end
 
   # Set the share, if it exists and is available to the current user

--- a/app/dashboards/share_dashboard.rb
+++ b/app/dashboards/share_dashboard.rb
@@ -12,7 +12,7 @@ class ShareDashboard < Administrate::BaseDashboard
   ATTRIBUTE_TYPES = {
     user: Field::BelongsTo,
     recipient: Field::Polymorphic,
-    birth_record: Field::BelongsTo,
+    document: Field::BelongsTo,
     id: Field::Number,
     created_at: Field::DateTime,
     updated_at: Field::DateTime,

--- a/app/dashboards/user_dashboard.rb
+++ b/app/dashboards/user_dashboard.rb
@@ -10,7 +10,7 @@ class UserDashboard < Administrate::BaseDashboard
   # which determines how the attribute is displayed
   # on pages throughout the dashboard.
   ATTRIBUTE_TYPES = {
-    birth_records: Field::HasMany,
+    user_documents: Field::HasMany,
     id: Field::Number,
     email: Field::String,
     reset_password_token: Field::String,
@@ -32,7 +32,7 @@ class UserDashboard < Administrate::BaseDashboard
   # By default, it's limited to four items to reduce clutter on index pages.
   # Feel free to add, remove, or rearrange items.
   COLLECTION_ATTRIBUTES = %i[
-    birth_records
+    user_documents
     id
     email
   ].freeze
@@ -40,7 +40,7 @@ class UserDashboard < Administrate::BaseDashboard
   # SHOW_PAGE_ATTRIBUTES
   # an array of attributes that will be displayed on the model's show page.
   SHOW_PAGE_ATTRIBUTES = %i[
-    birth_records
+    user_documents
     id
     email
     reset_password_token
@@ -59,7 +59,7 @@ class UserDashboard < Administrate::BaseDashboard
   # an array of attributes that will be displayed
   # on the model's form (`new` and `edit`) pages.
   FORM_ATTRIBUTES = %i[
-    birth_records
+    user_documents
     email
     reset_password_token
     reset_password_sent_at

--- a/app/dashboards/user_document_dashboard.rb
+++ b/app/dashboards/user_document_dashboard.rb
@@ -14,7 +14,7 @@ class UserDocumentDashboard < Administrate::BaseDashboard
     document: Field::Polymorphic,
     id: Field::Number,
     created_at: Field::DateTime,
-    updated_at: Field::DateTime,
+    updated_at: Field::DateTime
   }.freeze
 
   # COLLECTION_ATTRIBUTES

--- a/app/dashboards/user_document_dashboard.rb
+++ b/app/dashboards/user_document_dashboard.rb
@@ -2,7 +2,7 @@
 
 require 'administrate/base_dashboard'
 
-class ShareDashboard < Administrate::BaseDashboard
+class UserDocumentDashboard < Administrate::BaseDashboard
   # ATTRIBUTE_TYPES
   # a hash that describes the type of each of the model's fields.
   #
@@ -11,16 +11,10 @@ class ShareDashboard < Administrate::BaseDashboard
   # on pages throughout the dashboard.
   ATTRIBUTE_TYPES = {
     user: Field::BelongsTo,
-    recipient: Field::Polymorphic,
-    document_id: Field::Number,
-    document_type: Field::String,
+    document: Field::Polymorphic,
     id: Field::Number,
     created_at: Field::DateTime,
     updated_at: Field::DateTime,
-    revoked_by_type: Field::String,
-    revoked_by_id: Field::Number,
-    revoked_at: Field::DateTime,
-    last_accessed_at: Field::DateTime
   }.freeze
 
   # COLLECTION_ATTRIBUTES
@@ -30,26 +24,20 @@ class ShareDashboard < Administrate::BaseDashboard
   # Feel free to add, remove, or rearrange items.
   COLLECTION_ATTRIBUTES = %i[
     user
-    recipient
-    document_id
-    document_type
+    document
     id
+    created_at
+    updated_at
   ].freeze
 
   # SHOW_PAGE_ATTRIBUTES
   # an array of attributes that will be displayed on the model's show page.
   SHOW_PAGE_ATTRIBUTES = %i[
     user
-    recipient
-    document_id
-    document_type
+    document
     id
     created_at
     updated_at
-    revoked_by_type
-    revoked_by_id
-    revoked_at
-    last_accessed_at
   ].freeze
 
   # FORM_ATTRIBUTES
@@ -57,19 +45,13 @@ class ShareDashboard < Administrate::BaseDashboard
   # on the model's form (`new` and `edit`) pages.
   FORM_ATTRIBUTES = %i[
     user
-    recipient
-    document_id
-    document_type
-    revoked_by_type
-    revoked_by_id
-    revoked_at
-    last_accessed_at
+    document
   ].freeze
 
   # Overwrite this method to customize how shares are displayed
   # across all pages of the admin dashboard.
   #
   # def display_resource(share)
-  #   "Share ##{share.id}"
+  #   "UserDocument ##{user_document.id}"
   # end
 end

--- a/app/models/audit.rb
+++ b/app/models/audit.rb
@@ -3,13 +3,13 @@
 class Audit < Audited::Audit
   scope :viewing_birth_record, -> { where(comment: AuditedOperationsService::VIEW_SHARED_BIRTH_RECORD) }
   scope :sharing_birth_record, -> { where(comment: AuditedOperationsService::SHARE_BIRTH_RECORD) }
-  CUSTOM_RENDERING_TYPES = %w[share birth_records_user].freeze
+  CUSTOM_RENDERING_TYPES = %w[share user_document].freeze
 
   # Override the default partial path generator so we can render appropriate
   # different partials for each kind of audit
   #
   # This looks for partials based on the type of record associated with the
-  # audit (BirthRecordsUser, Share, View) in an appropriately named file, e.g.
+  # audit (UserDocument, Share, View) in an appropriately named file, e.g.
   # /audits/_share.html.erb
   #
   # Note that for namespaced controllers (User::SharesController) the partial

--- a/app/models/audit.rb
+++ b/app/models/audit.rb
@@ -1,9 +1,20 @@
 # frozen_string_literal: true
 
 class Audit < Audited::Audit
-  scope :viewing_birth_record, -> { where(comment: AuditedOperationsService::VIEW_SHARED_BIRTH_RECORD) }
-  scope :sharing_birth_record, -> { where(comment: AuditedOperationsService::SHARE_BIRTH_RECORD) }
+  scope :viewing_birth_record, -> { where(comment: VIEW_SHARED_BIRTH_RECORD) }
+  scope :sharing_birth_record, -> { where(comment: SHARE_BIRTH_RECORD) }
   CUSTOM_RENDERING_TYPES = %w[share user_document].freeze
+
+  # constants for User/BirthRecord actions
+  ADD_BIRTH_RECORD_TO_USER = 'ADD_BIRTH_RECORD_TO_USER'
+  REMOVE_BIRTH_RECORD_FROM_USER = 'REMOVE_BIRTH_RECORD_FROM_USER'
+
+  # constants for User/Share actions
+  SHARE_BIRTH_RECORD = 'SHARE_BIRTH_RECORD'
+  REVOKE_SHARE = 'REVOKE_SHARE'
+
+  # constants for Recipient/Share actions
+  VIEW_SHARED_BIRTH_RECORD = 'VIEW_SHARED_BIRTH_RECORD'
 
   # Override the default partial path generator so we can render appropriate
   # different partials for each kind of audit

--- a/app/models/birth_record.rb
+++ b/app/models/birth_record.rb
@@ -1,13 +1,8 @@
 # frozen_string_literal: true
 
 class BirthRecord < ApplicationRecord
+  include Document
   has_associated_audits
-
-  has_many :birth_records_users, dependent: :nullify
-  has_many :users, -> { distinct }, through: :birth_records_users
-  has_many :shares, -> { merge(Share.kept) }, dependent: :nullify, inverse_of: :birth_record
-
-  DOCUMENT_TYPE = 'birth_record'
 
   def date_of_birth
     format_date(self[:date_of_birth])
@@ -41,8 +36,26 @@ class BirthRecord < ApplicationRecord
     "#{family_name}, #{first_and_middle_names}"
   end
 
-  def document_type
-    DOCUMENT_TYPE
+  def share(user:, recipient:)
+    AuditedOperationsService.share_birth_record_with_recipient(
+      user: user,
+      birth_record: self,
+      recipient: recipient
+    )
+  end
+
+  def add_to(user)
+    AuditedOperationsService.add_birth_record_to_user(
+      user: user,
+      birth_record: self
+    )
+  end
+
+  def remove_from(user)
+    AuditedOperationsService.remove_birth_record_from_user(
+      user: user,
+      birth_record_id: id
+    )
   end
 
   private

--- a/app/models/birth_record.rb
+++ b/app/models/birth_record.rb
@@ -36,7 +36,7 @@ class BirthRecord < ApplicationRecord
     "#{family_name}, #{first_and_middle_names}"
   end
 
-  def share(user:, recipient:)
+  def share_with(user:, recipient:)
     AuditedOperationsService.share_birth_record_with_recipient(
       user: user,
       birth_record: self,

--- a/app/models/concerns/document.rb
+++ b/app/models/concerns/document.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+require 'active_support/concern'
+
+module Document
+  extend ActiveSupport::Concern
+
+  included do # rubocop:disable Metrics/BlockLength
+    has_many :user_documents, dependent: :nullify
+    has_many :users, -> { distinct }, through: :user_documents
+    has_many :shares, -> { merge(Share.kept) }, dependent: :nullify, inverse_of: :document, foreign_key: 'document_id'
+
+    def heading
+      to_s
+    end
+
+    def document_type
+      self.class.to_s
+    end
+
+    def add_to(user:)
+      user_documents.create(user: user)
+    end
+
+    def remove_from(user:)
+      ud = user_documents.find_by(user: user)
+      return nil if ud.blank?
+
+      ud.update(
+        discarded_at: Time.now.utc,
+        audit_comment: 'REMOVE_DOCUMENT_FROM_USER'
+      )
+    end
+
+    def share_with(recipient:, user:)
+      Share.create(
+        user: user,
+        document: self,
+        recipient: recipient,
+        audit_comment: 'SHARE_DOCUMENT'
+      )
+    end
+  end
+
+  class_methods do
+    def document_type
+      to_s
+    end
+  end
+end

--- a/app/models/concerns/document.rb
+++ b/app/models/concerns/document.rb
@@ -18,11 +18,11 @@ module Document
       self.class.to_s
     end
 
-    def add_to(user:)
+    def add_to(user)
       user_documents.create(user: user)
     end
 
-    def remove_from(user:)
+    def remove_from(user)
       ud = user_documents.find_by(user: user)
       return nil if ud.blank?
 

--- a/app/models/request.rb
+++ b/app/models/request.rb
@@ -14,7 +14,7 @@ class Request < ApplicationRecord
 
   delegate :email, to: :requestee, prefix: true, allow_nil: true
 
-  DOCUMENT_TYPES = [BirthRecord::DOCUMENT_TYPE].freeze
+  DOCUMENT_TYPES = %w[BirthRecord].freeze
   validates :document_type, inclusion: { in: DOCUMENT_TYPES }
   validates_associated :requestee
 

--- a/app/models/share.rb
+++ b/app/models/share.rb
@@ -21,8 +21,15 @@ class Share < ApplicationRecord
   scope :unrevoked, -> { where(revoked_by: nil) }
   scope :revoked, -> { where.not(revoked_by: nil) }
 
-  def revoke(revoked_by:)
+  def revoke(revoked_by: user)
     AuditedOperationsService.revoke_share(share: self, user: revoked_by)
+  end
+
+  def access(accessed_by:)
+    AuditedOperationsService.access_shared_birth_record(
+      share: self,
+      logged_identity: accessed_by
+    )
   end
 
   def revoked?

--- a/app/models/share.rb
+++ b/app/models/share.rb
@@ -6,7 +6,7 @@ class Share < ApplicationRecord
 
   audited associated_with: :user, comment_required: true
 
-  belongs_to :birth_record
+  belongs_to :document, polymorphic: true
   belongs_to :user
 
   belongs_to :recipient, polymorphic: true
@@ -14,12 +14,16 @@ class Share < ApplicationRecord
 
   validates :user, presence: true
   validates :recipient, presence: true
-  validates :birth_record, presence: true
+  validates :document, presence: true
 
   validate :not_currently_shared, on: :create
 
   scope :unrevoked, -> { where(revoked_by: nil) }
   scope :revoked, -> { where.not(revoked_by: nil) }
+
+  def revoke(revoked_by:)
+    AuditedOperationsService.revoke_share(share: self, user: revoked_by)
+  end
 
   def revoked?
     revoked_by.present?
@@ -34,7 +38,7 @@ class Share < ApplicationRecord
   # True if the user doesn't have any active (not soft deleted) shares of this
   # birth record with this recipient
   def not_currently_shared
-    return false unless Share.where(recipient: recipient, user: user, birth_record: birth_record).kept.any?
+    return false unless Share.where(recipient: recipient, user: user, document: document).kept.any?
 
     errors.add(:recipient, 'is currently shared with this entity')
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -7,8 +7,10 @@ class User < ApplicationRecord
          :recoverable, :rememberable, :validatable,
          :timeoutable, :trackable, :invitable
 
-  has_many :birth_records_users, dependent: :nullify
-  has_many :birth_records, -> { distinct.merge(BirthRecordsUser.kept) }, through: :birth_records_users
+  has_many :user_documents, dependent: :nullify
+  has_many :birth_records, -> { distinct.merge(UserDocument.kept) },
+           through: :user_documents,
+           source: :document, source_type: 'BirthRecord'
   has_many :shares, -> { merge(Share.kept) }, dependent: :nullify, inverse_of: :user
 
   has_many :organisation_members, dependent: :destroy
@@ -44,8 +46,8 @@ class User < ApplicationRecord
     organisations.include? organisation
   end
 
-  def documents(type: BirthRecord::DOCUMENT_TYPE)
-    return birth_records if type.to_s == BirthRecord::DOCUMENT_TYPE
+  def documents(type: 'BirthRecord')
+    return birth_records if type.to_s == 'BirthRecord'
 
     # one day there will be other types of documents, but for the moment...
     []

--- a/app/models/user_document.rb
+++ b/app/models/user_document.rb
@@ -1,10 +1,10 @@
 # frozen_string_literal: true
 
-class BirthRecordsUser < ApplicationRecord
+class UserDocument < ApplicationRecord
   include Discard::Model
 
   audited associated_with: :user, comment_required: true
 
   belongs_to :user
-  belongs_to :birth_record
+  belongs_to :document, polymorphic: true
 end

--- a/app/services/audited_operations_service.rb
+++ b/app/services/audited_operations_service.rb
@@ -22,9 +22,9 @@ class AuditedOperationsService
     raise ArgumentError, 'user cannot be nil' if user.nil?
 
     Audited.audit_class.as_user(user) do
-      user.birth_records_users << BirthRecordsUser.create!(
+      user.user_documents << UserDocument.create!(
         user: user,
-        birth_record: birth_record,
+        document: birth_record,
         audit_comment: ADD_BIRTH_RECORD_TO_USER
       )
     end
@@ -36,8 +36,8 @@ class AuditedOperationsService
     Audited.audit_class.as_user(user) do
       begin
         user
-          .birth_records_users
-          .find_by!(birth_record_id: birth_record_id)
+          .user_documents
+          .find_by!(document_id: birth_record_id)
           .update!(
             discarded_at: Time.now.utc,
             audit_comment: REMOVE_BIRTH_RECORD_FROM_USER
@@ -54,7 +54,7 @@ class AuditedOperationsService
     Audited.audit_class.as_user(user) do
       Share.create!(
         user: user,
-        birth_record: birth_record,
+        document: birth_record,
         recipient: recipient,
         audit_comment: SHARE_BIRTH_RECORD
       )
@@ -91,6 +91,6 @@ class AuditedOperationsService
 
     # logged_identity would be recorded in the BDM register access logs
     # official birth record would be returned here
-    share.birth_record
+    share.document
   end
 end

--- a/app/services/audited_operations_service.rb
+++ b/app/services/audited_operations_service.rb
@@ -7,17 +7,6 @@ class AuditedOperationsService
   class UnauthorisedAccessRequestError < StandardError
   end
 
-  # constants for User/BirthRecord actions
-  ADD_BIRTH_RECORD_TO_USER = 'ADD_BIRTH_RECORD_TO_USER'
-  REMOVE_BIRTH_RECORD_FROM_USER = 'REMOVE_BIRTH_RECORD_FROM_USER'
-
-  # constants for User/Share actions
-  SHARE_BIRTH_RECORD = 'SHARE_BIRTH_RECORD'
-  REVOKE_SHARE = 'REVOKE_SHARE'
-
-  # constants for Recipient/Share actions
-  VIEW_SHARED_BIRTH_RECORD = 'VIEW_SHARED_BIRTH_RECORD'
-
   def self.add_birth_record_to_user(user:, birth_record:)
     raise ArgumentError, 'user cannot be nil' if user.nil?
 
@@ -25,7 +14,7 @@ class AuditedOperationsService
       user.user_documents << UserDocument.create!(
         user: user,
         document: birth_record,
-        audit_comment: ADD_BIRTH_RECORD_TO_USER
+        audit_comment: Audit::ADD_BIRTH_RECORD_TO_USER
       )
     end
   end
@@ -40,7 +29,7 @@ class AuditedOperationsService
           .find_by!(document_id: birth_record_id)
           .update!(
             discarded_at: Time.now.utc,
-            audit_comment: REMOVE_BIRTH_RECORD_FROM_USER
+            audit_comment: Audit::REMOVE_BIRTH_RECORD_FROM_USER
           )
       rescue ActiveRecord::RecordNotFound
         return false
@@ -56,7 +45,7 @@ class AuditedOperationsService
         user: user,
         document: birth_record,
         recipient: recipient,
-        audit_comment: SHARE_BIRTH_RECORD
+        audit_comment: Audit::SHARE_BIRTH_RECORD
       )
     end
   end
@@ -68,7 +57,7 @@ class AuditedOperationsService
       share.update!(
         revoked_by: user,
         revoked_at: Time.now.utc,
-        audit_comment: REVOKE_SHARE
+        audit_comment: Audit::REVOKE_SHARE
       )
     end
   end
@@ -82,7 +71,7 @@ class AuditedOperationsService
     Audited.audit_class.as_user(logged_identity) do
       share.update!(
         last_accessed_at: Time.now.utc,
-        audit_comment: VIEW_SHARED_BIRTH_RECORD
+        audit_comment: Audit::VIEW_SHARED_BIRTH_RECORD
       )
     end
 

--- a/app/views/organisation_member/dashboard/index.html.erb
+++ b/app/views/organisation_member/dashboard/index.html.erb
@@ -22,7 +22,7 @@
   <div class="row">
     <% @shares.each do |share| %>
       <div class="col-sm-4 mb-4">
-        <%= render partial: 'shared/documents/preview', locals: { document: share.birth_record,
+        <%= render partial: 'shared/documents/preview', locals: { document: share.document,
           shared_by: share.user.email,
           actions: [
             link_to('View', organisation_member_share_path(@organisation, share), class: 'btn btn-secondary')

--- a/app/views/organisation_member/requests/show.html.erb
+++ b/app/views/organisation_member/requests/show.html.erb
@@ -47,7 +47,7 @@
         <% if @request.share.present? && policy(@request.share).show? %>
           <dt>Shared document</dt>
           <%= render partial: 'shared/documents/preview', locals: {
-            document: @request.share.birth_record, actions: [
+            document: @request.share.document, actions: [
               link_to('View', organisation_member_share_path(@organisation, @request.share), class: 'btn btn-secondary'),
               ]
             }

--- a/app/views/organisation_member/shares/index.html.erb
+++ b/app/views/organisation_member/shares/index.html.erb
@@ -19,7 +19,7 @@
     <tbody>
       <% @shares.each do |share| %>
         <tr>
-          <td><%= share.birth_record.short_name %></td>
+          <td><%= share.document.short_name %></td>
           <td><%= share.user.email %></td>
           <td><%= share.recipient.name %></td>
           <td><%= link_to 'Show', organisation_member_share_path(@organisation, share) %></td>

--- a/app/views/user/audits/_share.html.erb
+++ b/app/views/user/audits/_share.html.erb
@@ -5,17 +5,17 @@
   <div class="card-body">
     <h5 class="card-title">
       <% if audit.comment == AuditedOperationsService::SHARE_BIRTH_RECORD%>
-        <strong>Share</strong> birth record of <strong><%= audit.auditable.birth_record.full_name %></strong>
+        <strong>Share</strong> birth record of <strong><%= audit.auditable.document.full_name %></strong>
         <div class="text-muted">
           with <strong><%= audit.auditable.recipient.name %></strong>
         </div>
       <% elsif audit.comment == AuditedOperationsService::REVOKE_SHARE %>
-        <strong>Revoke</strong> sharing of birth record of <strong><%= audit.auditable.birth_record.full_name %></strong>
+        <strong>Revoke</strong> sharing of birth record of <strong><%= audit.auditable.document.full_name %></strong>
         <div class="text-muted">
           with <strong><%= audit.auditable.recipient.name %></strong>
         </div>
       <% elsif audit.comment == AuditedOperationsService::VIEW_SHARED_BIRTH_RECORD %>
-        <strong>View</strong> birth record of <strong><%= audit.auditable.birth_record.full_name %></strong>
+        <strong>View</strong> birth record of <strong><%= audit.auditable.document.full_name %></strong>
         <div class="text-muted">
           by <strong><%= audit.auditable.recipient.name %></strong>
         </div>

--- a/app/views/user/audits/_share.html.erb
+++ b/app/views/user/audits/_share.html.erb
@@ -4,17 +4,17 @@
 <div class="card audit" data-id="<%= audit.id %>">
   <div class="card-body">
     <h5 class="card-title">
-      <% if audit.comment == AuditedOperationsService::SHARE_BIRTH_RECORD%>
+      <% if audit.comment == Audit::SHARE_BIRTH_RECORD%>
         <strong>Share</strong> birth record of <strong><%= audit.auditable.document.full_name %></strong>
         <div class="text-muted">
           with <strong><%= audit.auditable.recipient.name %></strong>
         </div>
-      <% elsif audit.comment == AuditedOperationsService::REVOKE_SHARE %>
+      <% elsif audit.comment == Audit::REVOKE_SHARE %>
         <strong>Revoke</strong> sharing of birth record of <strong><%= audit.auditable.document.full_name %></strong>
         <div class="text-muted">
           with <strong><%= audit.auditable.recipient.name %></strong>
         </div>
-      <% elsif audit.comment == AuditedOperationsService::VIEW_SHARED_BIRTH_RECORD %>
+      <% elsif audit.comment == Audit::VIEW_SHARED_BIRTH_RECORD %>
         <strong>View</strong> birth record of <strong><%= audit.auditable.document.full_name %></strong>
         <div class="text-muted">
           by <strong><%= audit.auditable.recipient.name %></strong>

--- a/app/views/user/audits/_user_document.html.erb
+++ b/app/views/user/audits/_user_document.html.erb
@@ -1,16 +1,16 @@
 <% # Normalise auto-assigned variable %>
-<% audit ||= birth_records_user %>
+<% audit ||= user_document %>
 
 <div class="card audit" data-id="<%= audit.id %>">
   <div class="card-body">
     <h5 class="card-title">
       <% if audit.action == 'create'%>
-        <strong>Add</strong> birth record of <strong><%= audit.auditable.birth_record.full_name %></strong>
+        <strong>Add</strong> birth record of <strong><%= audit.auditable.document.full_name %></strong>
         <div class="text-muted">
            to your documents
         </div>
       <% else %>
-        <strong>Remove</strong> birth record of <strong><%= audit.auditable.birth_record.full_name %></strong>
+        <strong>Remove</strong> birth record of <strong><%= audit.auditable.document.full_name %></strong>
         <div class="text-muted">
           From Your Documents
         </div>

--- a/app/views/user/requests/show.html.erb
+++ b/app/views/user/requests/show.html.erb
@@ -51,8 +51,8 @@
       <div class="col-sm-6">
         <% if @request.share.present? %>
           <dt>Shared document</dt>
-          <%= render partial: 'shared/documents/preview', locals: { document: @request.share.birth_record , actions: [
-            link_to('View', user_birth_record_path(@request.share.birth_record), class: 'btn btn-secondary')
+          <%= render partial: 'shared/documents/preview', locals: { document: @request.share.document , actions: [
+            link_to('View', user_birth_record_path(@request.share.document), class: 'btn btn-secondary')
           ]} %>
         <% end %>
       </div>

--- a/app/views/user/shares/_form.html.erb
+++ b/app/views/user/shares/_form.html.erb
@@ -3,7 +3,7 @@
   <div>
     Sharing birth record of <%= record.full_name %>
   </div>
-  <%= f.hidden_field :birth_record_id, value: record.id %>
+  <%= f.hidden_field :document_id, value: record.id %>
   <%= f.hidden_field :recipient_id, id: 'recipient_id', value: nil %>
   <div >
     <%= f.text_field :organisation, id: "org-query", label_as_placeholder: true, label: 'Organisation' %>

--- a/app/views/user/shares/index.html.erb
+++ b/app/views/user/shares/index.html.erb
@@ -17,7 +17,7 @@
     <tbody>
       <% @shares.each do |share| %>
         <tr>
-          <td><%= share.birth_record.short_name %></td>
+          <td><%= share.document.title %></td>
           <td><%= share.user.email %></td>
           <td><%= share.recipient.name %></td>
           <td><%= link_to 'Show', user_share_path(share) %></td>

--- a/app/views/user/shares/show.html.erb
+++ b/app/views/user/shares/show.html.erb
@@ -2,7 +2,7 @@
 <p class="lead">You have shared this with <%= @share.recipient.name %>.</p>
 <p>
   <strong>Birth record:</strong>
-  <%= render partial: 'shared/birth_records/short_details', object: @share.birth_record %>
+  <%= render partial: 'shared/birth_records/short_details', object: @share.document %>
 </p>
 
 <p>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -33,4 +33,4 @@ en:
   hello: "Hello world"
   documents:
     types:
-      birth_record: "Birth record"
+      BirthRecord: "Birth record"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,6 +9,7 @@ Rails.application.routes.draw do
     resources :admin_users
     resources :birth_records
     resources :shares
+    resources :user_documents
     resources :organisations
     resources :organisation_members
 

--- a/db/migrate/20190829044246_abstract_birth_records_to_documents.rb
+++ b/db/migrate/20190829044246_abstract_birth_records_to_documents.rb
@@ -7,6 +7,7 @@ class AbstractBirthRecordsToDocuments < ActiveRecord::Migration[5.2]
     rename_column :shares, :birth_record_id, :document_id
     execute("UPDATE shares SET document_type = 'BirthRecord' WHERE document_type IS null")
     execute("UPDATE user_documents SET document_type = 'BirthRecord' WHERE document_type IS null")
+    execute("UPDATE requests SET document_type = 'BirthRecord' WHERE document_type = 'birth_record'")
   end
 
   def down
@@ -15,5 +16,6 @@ class AbstractBirthRecordsToDocuments < ActiveRecord::Migration[5.2]
     rename_column :shares, :document_id, :birth_record_id
     remove_column :birth_records_users, :document_type
     remove_column :shares, :document_type
+    execute("UPDATE requests SET document_type = 'birth_record' WHERE document_type = 'BirthRecord'")
   end
 end

--- a/db/migrate/20190829044246_abstract_birth_records_to_documents.rb
+++ b/db/migrate/20190829044246_abstract_birth_records_to_documents.rb
@@ -1,0 +1,19 @@
+class AbstractBirthRecordsToDocuments < ActiveRecord::Migration[5.2]
+  def up
+    rename_table :birth_records_users, :user_documents
+    add_column :user_documents, :document_type, :string
+    rename_column :user_documents, :birth_record_id, :document_id
+    add_column :shares, :document_type, :string
+    rename_column :shares, :birth_record_id, :document_id
+    execute("UPDATE shares SET document_type = 'BirthRecord' WHERE document_type IS null")
+    execute("UPDATE user_documents SET document_type = 'BirthRecord' WHERE document_type IS null")
+  end
+
+  def down
+    rename_table :user_documents, :birth_records_users
+    rename_column :birth_records_users, :document_id, :birth_record_id
+    rename_column :shares, :document_id, :birth_record_id
+    remove_column :birth_records_users, :document_type
+    remove_column :shares, :document_type
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_08_20_085902) do
+ActiveRecord::Schema.define(version: 2019_08_29_044246) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -70,15 +70,6 @@ ActiveRecord::Schema.define(version: 2019_08_20_085902) do
     t.index ["first_and_middle_names"], name: "index_birth_records_on_first_and_middle_names"
   end
 
-  create_table "birth_records_users", force: :cascade do |t|
-    t.bigint "user_id", null: false
-    t.bigint "birth_record_id", null: false
-    t.datetime "discarded_at"
-    t.index ["birth_record_id", "user_id"], name: "index_birth_records_users_on_birth_record_id_and_user_id"
-    t.index ["discarded_at"], name: "index_birth_records_users_on_discarded_at"
-    t.index ["user_id", "birth_record_id"], name: "index_birth_records_users_on_user_id_and_birth_record_id"
-  end
-
   create_table "organisation_members", force: :cascade do |t|
     t.bigint "user_id", null: false
     t.bigint "organisation_id", null: false
@@ -132,7 +123,7 @@ ActiveRecord::Schema.define(version: 2019_08_20_085902) do
 
   create_table "shares", force: :cascade do |t|
     t.bigint "user_id", null: false
-    t.bigint "birth_record_id", null: false
+    t.bigint "document_id", null: false
     t.string "recipient_type", null: false
     t.bigint "recipient_id", null: false
     t.datetime "created_at", null: false
@@ -141,11 +132,22 @@ ActiveRecord::Schema.define(version: 2019_08_20_085902) do
     t.bigint "revoked_by_id"
     t.datetime "revoked_at"
     t.datetime "last_accessed_at"
-    t.index ["birth_record_id"], name: "index_shares_on_birth_record_id"
+    t.string "document_type"
+    t.index ["document_id"], name: "index_shares_on_document_id"
     t.index ["recipient_type", "recipient_id"], name: "index_shares_on_recipient_type_and_recipient_id"
     t.index ["revoked_at"], name: "index_shares_on_revoked_at"
     t.index ["revoked_by_type", "revoked_by_id"], name: "index_shares_on_revoked_by_type_and_revoked_by_id"
     t.index ["user_id"], name: "index_shares_on_user_id"
+  end
+
+  create_table "user_documents", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.bigint "document_id", null: false
+    t.datetime "discarded_at"
+    t.string "document_type"
+    t.index ["discarded_at"], name: "index_user_documents_on_discarded_at"
+    t.index ["document_id", "user_id"], name: "index_user_documents_on_document_id_and_user_id"
+    t.index ["user_id", "document_id"], name: "index_user_documents_on_user_id_and_document_id"
   end
 
   create_table "users", force: :cascade do |t|

--- a/spec/controllers/admin/birth_records_controller_spec.rb
+++ b/spec/controllers/admin/birth_records_controller_spec.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Admin::BirthRecordsController do
+  context 'when logged in as admin' do
+    before do
+      sign_in(FactoryBot.create(:admin_user))
+    end
+    it 'renders an index of birth records' do
+      get :index
+      expect(response).to have_http_status(200)
+    end
+    it 'shows one birth record' do
+      birth_record = FactoryBot.create(:birth_record)
+      get :show, params: { id: birth_record.id }
+      expect(response).to have_http_status(200)
+    end
+  end
+  context 'when logged in as a normal user' do
+    before do
+      sign_in(FactoryBot.create(:user))
+    end
+    it 'redirects back to user root' do
+      get :index
+      expect(response).to have_http_status(302)
+    end
+  end
+  context 'when not logged in' do
+    it 'redirects to login' do
+      get :index
+      expect(response).to have_http_status(302)
+    end
+  end
+end

--- a/spec/controllers/admin/organisation_members_controller_spec.rb
+++ b/spec/controllers/admin/organisation_members_controller_spec.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Admin::OrganisationMembersController do
+  context 'when logged in as admin' do
+    before do
+      sign_in(FactoryBot.create(:admin_user))
+    end
+    it 'renders an index of organisation_members' do
+      get :index
+      expect(response).to have_http_status(200)
+    end
+    it 'shows one organisation_member' do
+      organisation_member = FactoryBot.create(:organisation_member)
+      get :show, params: { id: organisation_member.id }
+      expect(response).to have_http_status(200)
+    end
+  end
+  context 'when logged in as a normal user' do
+    before do
+      sign_in(FactoryBot.create(:user))
+    end
+    it 'redirects back to user root' do
+      get :index
+      expect(response).to have_http_status(302)
+    end
+  end
+  context 'when not logged in' do
+    it 'redirects to login' do
+      get :index
+      expect(response).to have_http_status(302)
+    end
+  end
+end

--- a/spec/controllers/admin/organisations_controller_spec.rb
+++ b/spec/controllers/admin/organisations_controller_spec.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Admin::OrganisationsController do
+  context 'when logged in as admin' do
+    before do
+      sign_in(FactoryBot.create(:admin_user))
+    end
+    it 'renders an index of organisations' do
+      get :index
+      expect(response).to have_http_status(200)
+    end
+    it 'shows one organisation' do
+      organisation = FactoryBot.create(:organisation)
+      get :show, params: { id: organisation.id }
+      expect(response).to have_http_status(200)
+    end
+  end
+  context 'when logged in as a normal user' do
+    before do
+      sign_in(FactoryBot.create(:user))
+    end
+    it 'redirects back to user root' do
+      get :index
+      expect(response).to have_http_status(302)
+    end
+  end
+  context 'when not logged in' do
+    it 'redirects to login' do
+      get :index
+      expect(response).to have_http_status(302)
+    end
+  end
+end

--- a/spec/controllers/admin/shares_controller_spec.rb
+++ b/spec/controllers/admin/shares_controller_spec.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Admin::SharesController do
+  context 'when logged in as admin' do
+    before do
+      sign_in(FactoryBot.create(:admin_user))
+    end
+    it 'renders an index of shares' do
+      get :index
+      expect(response).to have_http_status(200)
+    end
+    it 'shows one share' do
+      share = FactoryBot.create(:share)
+      get :show, params: { id: share.id }
+      expect(response).to have_http_status(200)
+    end
+  end
+  context 'when logged in as a normal user' do
+    before do
+      sign_in(FactoryBot.create(:user))
+    end
+    it 'redirects back to user root' do
+      get :index
+      expect(response).to have_http_status(302)
+    end
+  end
+  context 'when not logged in' do
+    it 'redirects to login' do
+      get :index
+      expect(response).to have_http_status(302)
+    end
+  end
+end

--- a/spec/controllers/admin/user_documents_controller_spec.rb
+++ b/spec/controllers/admin/user_documents_controller_spec.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Admin::UserDocumentsController do
+  context 'when logged in as admin' do
+    before do
+      sign_in(FactoryBot.create(:admin_user))
+    end
+    it 'renders an index of user_documents' do
+      get :index
+      expect(response).to have_http_status(200)
+    end
+    it 'shows one user_document' do
+      user_document = FactoryBot.create(:user_document)
+      get :show, params: { id: user_document.id }
+      expect(response).to have_http_status(200)
+    end
+  end
+  context 'when logged in as a normal user' do
+    before do
+      sign_in(FactoryBot.create(:user))
+    end
+    it 'redirects back to user root' do
+      get :index
+      expect(response).to have_http_status(302)
+    end
+  end
+  context 'when not logged in' do
+    it 'redirects to login' do
+      get :index
+      expect(response).to have_http_status(302)
+    end
+  end
+end

--- a/spec/controllers/admin/users_controller_spec.rb
+++ b/spec/controllers/admin/users_controller_spec.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Admin::UsersController do
+  context 'when logged in as admin' do
+    before do
+      sign_in(FactoryBot.create(:admin_user))
+    end
+    it 'renders an index of users' do
+      get :index
+      expect(response).to have_http_status(200)
+    end
+    it 'shows one user' do
+      user = FactoryBot.create(:user)
+      get :show, params: { id: user.id }
+      expect(response).to have_http_status(200)
+    end
+  end
+  context 'when logged in as a normal user' do
+    before do
+      sign_in(FactoryBot.create(:user))
+    end
+    it 'redirects back to user root' do
+      get :index
+      expect(response).to have_http_status(302)
+    end
+  end
+  context 'when not logged in' do
+    it 'redirects to login' do
+      get :index
+      expect(response).to have_http_status(302)
+    end
+  end
+end

--- a/spec/controllers/user/shares_controller_spec.rb
+++ b/spec/controllers/user/shares_controller_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe User::SharesController, type: :controller do
       context 'with valid params' do
         let(:birth_record) { FactoryBot.create(:birth_record) }
         let!(:birth_records_user) do
-          FactoryBot.create(:birth_records_user, birth_record: birth_record, user: user)
+          FactoryBot.create(:user_document, document: birth_record, user: user)
         end
         let(:valid_attributes) do
           FactoryBot
@@ -46,7 +46,7 @@ RSpec.describe User::SharesController, type: :controller do
               :share,
               user: user,
               recipient: FactoryBot.create(:organisation),
-              birth_record: birth_record
+              document: birth_record
             )
             .attributes
         end
@@ -59,7 +59,7 @@ RSpec.describe User::SharesController, type: :controller do
 
         it 'redirects to the created share' do
           post :create, params: { share: valid_attributes }
-          expect(response).to redirect_to(user_birth_record_path(Share.last.birth_record))
+          expect(response).to redirect_to(user_birth_record_path(Share.last.document))
         end
       end
 

--- a/spec/factories/request.rb
+++ b/spec/factories/request.rb
@@ -5,7 +5,7 @@ FactoryBot.define do
     association :requestee, factory: :user
     association :requester, factory: :organisation
     share_id { nil }
-    document_type { 'birth_record' }
+    document_type { 'BirthRecord' }
     note { 'Please share the birth record of Hemi' }
     trait :cancelled do
       after(:create) do |request, _evaluator|

--- a/spec/factories/share.rb
+++ b/spec/factories/share.rb
@@ -4,7 +4,7 @@ FactoryBot.define do
   factory :share do
     association :document, factory: :birth_record
     user
-    audit_comment { AuditedOperationsService::SHARE_BIRTH_RECORD }
+    audit_comment { Audit::SHARE_BIRTH_RECORD }
     for_organisation
 
     trait :for_organisation do
@@ -13,7 +13,7 @@ FactoryBot.define do
 
     trait :revoked do
       after(:create) do |share, _evaluator|
-        AuditedOperationsService.revoke_share(user: share.user, share: share)
+        share.revoke(revoked_by: share.user)
       end
     end
   end

--- a/spec/factories/share.rb
+++ b/spec/factories/share.rb
@@ -2,7 +2,7 @@
 
 FactoryBot.define do
   factory :share do
-    birth_record
+    association :document, factory: :birth_record
     user
     audit_comment { AuditedOperationsService::SHARE_BIRTH_RECORD }
     for_organisation

--- a/spec/factories/user_document.rb
+++ b/spec/factories/user_document.rb
@@ -4,6 +4,6 @@ FactoryBot.define do
   factory :user_document do
     association :document, factory: :birth_record
     user
-    audit_comment { AuditedOperationsService::ADD_BIRTH_RECORD_TO_USER }
+    audit_comment { Audit::ADD_BIRTH_RECORD_TO_USER }
   end
 end

--- a/spec/factories/user_document.rb
+++ b/spec/factories/user_document.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
 FactoryBot.define do
-  factory :birth_records_user do
-    birth_record
+  factory :user_document do
+    association :document, factory: :birth_record
     user
     audit_comment { AuditedOperationsService::ADD_BIRTH_RECORD_TO_USER }
   end

--- a/spec/features/organisation_members_spec.rb
+++ b/spec/features/organisation_members_spec.rb
@@ -21,8 +21,8 @@ RSpec.describe 'acting on behalf of an organisation', type: :feature do
     let!(:declined_request) { FactoryBot.create(:request, :declined, requester: organisation) }
     it 'shows unrevoked shares' do
       visit organisation_member_dashboard_path(organisation)
-      expect(page).to have_content(unrevoked_share.birth_record.heading)
-      expect(page).not_to have_content(revoked_share.birth_record.heading)
+      expect(page).to have_content(unrevoked_share.document.heading)
+      expect(page).not_to have_content(revoked_share.document.heading)
     end
     it 'shows unresolved requests' do
       visit organisation_member_dashboard_path(organisation)

--- a/spec/features/request_spec.rb
+++ b/spec/features/request_spec.rb
@@ -116,13 +116,9 @@ RSpec.describe 'sending a request from an organisation', type: :feature do
     let(:recipient) { FactoryBot.create(:user) }
 
     before do
-      FactoryBot.create(:birth_records_user, user: recipient, birth_record: birth_record)
-      first_share = AuditedOperationsService.share_birth_record_with_recipient(
-        user: recipient,
-        recipient: organisation,
-        birth_record: birth_record
-      )
-      AuditedOperationsService.revoke_share(user: recipient, share: first_share)
+      FactoryBot.create(:user_document, user: recipient, document: birth_record)
+      first_share = birth_record.share_with(recipient: organisation, user: user)
+      first_share.revoke
       FactoryBot.create(:request, requestee: recipient, requester: organisation)
 
       login_as(recipient, scope: :user)

--- a/spec/features/request_spec.rb
+++ b/spec/features/request_spec.rb
@@ -85,7 +85,7 @@ RSpec.describe 'sending a request from an organisation', type: :feature do
     context 'the user responding to the request' do
       let(:birth_record) { FactoryBot.create(:birth_record, :static_details) }
       before do
-        FactoryBot.create(:birth_records_user, user: recipient, birth_record: birth_record)
+        FactoryBot.create(:user_document, user: recipient, document: birth_record)
         recipient.reload
       end
       it 'marks the request as received when the recipient views it' do

--- a/spec/features/user_share_spec.rb
+++ b/spec/features/user_share_spec.rb
@@ -17,9 +17,9 @@ RSpec.describe 'user/SharesController', type: :feature do
   before do
     travel_to Time.zone.local('2019-01-01') # So Percy visual diffs show the same time
     birth_records.each do |birth_record|
-      AuditedOperationsService.add_birth_record_to_user(birth_record: birth_record, user: user)
+      birth_record.add_to(user)
     end
-    AuditedOperationsService.add_birth_record_to_user(birth_record: target_birth_record, user: user)
+    target_birth_record.add_to(user)
   end
   after do
     travel_back

--- a/spec/models/birth_record_spec.rb
+++ b/spec/models/birth_record_spec.rb
@@ -35,13 +35,13 @@ RSpec.describe BirthRecord, type: :model do
     let(:birth_record) { FactoryBot.create :birth_record }
     let(:user) { FactoryBot.create :user }
     let(:recipient) { FactoryBot.create :organisation }
-    it "don't make duplicate shares" do
-      FactoryBot.create :share, birth_record: birth_record,
+    it "doesn't make duplicate shares" do
+      FactoryBot.create :share, document: birth_record,
                                 user: user, recipient: recipient
       expect(birth_record.shares.size).to eq 1
 
       expect do
-        FactoryBot.create :share, birth_record: birth_record,
+        FactoryBot.create :share, document: birth_record,
                                   user: user, recipient: recipient
       end.to raise_error ActiveRecord::RecordInvalid
     end

--- a/spec/models/share_spec.rb
+++ b/spec/models/share_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe Share, type: :model do
 
   describe '#revoke' do
     it 'sets revoked_by and revoked_at' do
-      AuditedOperationsService.revoke_share(share: subject, user: user)
+      subject.revoke(revoked_by: user)
 
       subject.reload
 

--- a/spec/models/share_spec.rb
+++ b/spec/models/share_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe Share, type: :model do
       end
       it 'allows the creation of a new share' do
         new_share = AuditedOperationsService.share_birth_record_with_recipient(
-          birth_record: share.birth_record,
+          birth_record: share.document,
           user: share.user,
           recipient: share.recipient
         )

--- a/spec/models/user_document_spec.rb
+++ b/spec/models/user_document_spec.rb
@@ -2,9 +2,9 @@
 
 require 'rails_helper'
 
-RSpec.describe BirthRecordsUser, type: :model do
+RSpec.describe UserDocument, type: :model do
   describe 'Factory' do
-    subject { FactoryBot.create(:birth_records_user) }
+    subject { FactoryBot.create(:user_document) }
 
     it 'is valid' do
       expect(subject).to be_valid

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -73,13 +73,13 @@ RSpec.describe User, type: :model do
     let(:user) { FactoryBot.create(:user) }
     let(:birth_record) { FactoryBot.create(:birth_record) }
     before do
-      FactoryBot.create(:birth_records_user, birth_record: birth_record, user: user)
+      FactoryBot.create(:user_document, document: birth_record, user: user)
     end
     it 'returns birth records by default' do
       expect(user.documents).to eq([birth_record])
     end
     it 'returns birth records when passed birth_record as a document type' do
-      expect(user.documents(type: 'birth_record')).to eq([birth_record])
+      expect(user.documents(type: 'BirthRecord')).to eq([birth_record])
     end
     it 'returns an empty array when passed any other document type' do
       expect(user.documents(type: 'passport')).to eq([])

--- a/spec/request/user_audits_spec.rb
+++ b/spec/request/user_audits_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe 'user/AuditsController', type: :request do
       context 'when the user has added a birth record' do
         let(:birth_record) { FactoryBot.create(:birth_record) }
         before do
-          AuditedOperationsService.add_birth_record_to_user(user: user, birth_record: birth_record)
+          birth_record.add_to(user)
         end
 
         it 'the view shows an audit for it' do
@@ -29,11 +29,7 @@ RSpec.describe 'user/AuditsController', type: :request do
           let(:organisation) { FactoryBot.create(:organisation) }
 
           before do
-            AuditedOperationsService.share_birth_record_with_recipient(
-              user: user,
-              birth_record: birth_record,
-              recipient: organisation
-            )
+            birth_record.share_with(recipient: organisation, user: user)
           end
 
           it 'the view shows an audit for it' do
@@ -46,7 +42,7 @@ RSpec.describe 'user/AuditsController', type: :request do
 
           context 'then they revoke the share' do
             before do
-              AuditedOperationsService.revoke_share(user: user, share: user.shares.last)
+              user.shares.last.revoke(revoked_by: user)
             end
 
             it 'the view shows an audit for it' do
@@ -63,7 +59,7 @@ RSpec.describe 'user/AuditsController', type: :request do
 
         context 'then they remove the birth record' do
           before do
-            AuditedOperationsService.remove_birth_record_from_user(user: user, birth_record_id: birth_record.id)
+            birth_record.remove_from(user)
           end
 
           it 'the view shows an audit for it' do

--- a/spec/request/user_birth_record_spec.rb
+++ b/spec/request/user_birth_record_spec.rb
@@ -81,7 +81,7 @@ RSpec.describe 'user/BirthRecordsController', type: :request do
       context 'when a birth record is associated with the user' do
         let(:birth_record) { FactoryBot.create(:birth_record) }
         before do
-          AuditedOperationsService.add_birth_record_to_user(birth_record: birth_record, user: user)
+          birth_record.add_to(user)
         end
 
         it 'adding it again is a no-op' do

--- a/spec/request/user_birth_record_spec.rb
+++ b/spec/request/user_birth_record_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe 'user/BirthRecordsController', type: :request do
       context 'when a birth record is associated with the user' do
         let(:birth_record) { FactoryBot.create(:birth_record) }
         before do
-          AuditedOperationsService.add_birth_record_to_user(birth_record: birth_record, user: user)
+          birth_record.add_to(user)
         end
 
         it 'the view lists it' do
@@ -48,7 +48,7 @@ RSpec.describe 'user/BirthRecordsController', type: :request do
       context 'when a birth record is associated with the user' do
         let(:birth_record) { FactoryBot.create(:birth_record) }
         before do
-          AuditedOperationsService.add_birth_record_to_user(birth_record: birth_record, user: user)
+          birth_record.add_to(user)
         end
 
         it 'they can view it' do
@@ -113,7 +113,7 @@ RSpec.describe 'user/BirthRecordsController', type: :request do
       context 'when a birth record is associated with the user' do
         let(:birth_record) { FactoryBot.create(:birth_record) }
         before do
-          AuditedOperationsService.add_birth_record_to_user(birth_record: birth_record, user: user)
+          birth_record.add_to(user)
         end
 
         it 'is removed' do


### PR DESCRIPTION
- Create a document concern for other types of documents to include
- Shares now refer to a document rather than a birth_record
- Rename `birth_records_user` to `user_documents`
- Move calls to `AuditedOperationsService` to the `BirthRecord` model, rather than controllers

To do:

- [x] Thorough manual test
- [x] Update admin interfaces