### PR TITLE
Removed the subtitle on the Dashboard page.

### DIFF
--- a/app/views/organisation_member/dashboard/index.html.erb
+++ b/app/views/organisation_member/dashboard/index.html.erb
@@ -1,6 +1,3 @@
-<%= content_for :subhead do %>
-  <%= render partial: "organisation_member/shared/subhead" %>
-<% end %>
 <h1 class="pt-3 pb-2"><%= @organisation.name %>'s documents dashboard</h1>
 <h3>This is where your documents are stored. This is where you can request documents, view them, or remove your access to them.</h3>
 


### PR DESCRIPTION
Removed the subtitle on the Dashboard page.

Trello: https://trello.com/c/AHrmdyBw/98-the-green-notification-bar-has-the-name-of-the-organisation-this-can-be-removed-as-the-title-of-the-page-says-this-is-the-dashbo
![image](https://user-images.githubusercontent.com/13788498/65192815-a51f8280-dacc-11e9-87ac-a1a7067f57a1.png)
