### PR TITLE
Remove flex declarations from body

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -15,7 +15,7 @@
     <%= javascript_include_tag 'application' %>
   </head>
 
-  <body class="<%= action_in_bem_format %> <%= devise_flag %> min-vh-100 d-flex flex-column">
+  <body class="<%= action_in_bem_format %> <%= devise_flag %> min-vh-100">
     <%= render "shared/header" %>
     <%= yield :subhead %>
     <%= render "shared/flash_messages" %>


### PR DESCRIPTION
Not sure why they were here, they are making things weird in safari some of the time