### PR TITLE
🐛Fix links to immunisation records in request responses

### DIFF
--- a/app/views/user/requests/show.html.erb
+++ b/app/views/user/requests/show.html.erb
@@ -50,7 +50,7 @@
         <% if @request.share.present? %>
           <dt>Shared document</dt>
           <%= render partial: 'shared/documents/preview', locals: { document: @request.share.document , actions: [
-            link_to('View', user_birth_record_path(@request.share.document), class: 'btn btn-secondary')
+            link_to('View', user_document_path(@request.share.document.document_type, @request.share.document.id), class: 'btn btn-secondary')
           ]} %>
         <% end %>
       </div>


### PR DESCRIPTION
Currently this link causes a 500 error if an immunisation record has been shared

Need to deploy this by a demo at 12 - fyi @Br3nda 